### PR TITLE
Fix satellite defaults per instance and add tests

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,5 @@
+"""Expose core dataclasses for external use."""
+
+from .models import CurveData, GraphData
+
+__all__ = ["CurveData", "GraphData"]

--- a/core/models.py
+++ b/core/models.py
@@ -52,20 +52,32 @@ class GraphData:
     y_unit: str = ""
     x_format: str = "normal"  # valeurs possibles : "normal", "scientific", "scaled"
     y_format: str = "normal"
-    satellite_zones_visible = {"left": True, "right": True, "top": True, "bottom": True}
+    satellite_zones_visible: dict[str, bool] = field(
+        default_factory=lambda: {
+            "left": True,
+            "right": True,
+            "top": True,
+            "bottom": True,
+        }
+    )
 
-    satellite_visibility = {
-        "left": False,
-        "right": False,
-        "top": False,
-        "bottom": False
-    }
-    satellite_content = {
-        "left": None,
-        "right": None,
-        "top": None,
-        "bottom": None
-    }
+    satellite_visibility: dict[str, bool] = field(
+        default_factory=lambda: {
+            "left": False,
+            "right": False,
+            "top": False,
+            "bottom": False,
+        }
+    )
+
+    satellite_content: dict[str, Optional[str]] = field(
+        default_factory=lambda: {
+            "left": None,
+            "right": None,
+            "top": None,
+            "bottom": None,
+        }
+    )
 
 
     def add_curve(self, curve: CurveData):

--- a/tests/test_graph_data.py
+++ b/tests/test_graph_data.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core import GraphData
+
+
+def test_satellite_dicts_are_instance_specific():
+    g1 = GraphData("g1")
+    g2 = GraphData("g2")
+
+    g1.satellite_visibility["left"] = True
+    g1.satellite_content["right"] = "label"
+
+    assert g2.satellite_visibility["left"] is False
+    assert g2.satellite_content["right"] is None


### PR DESCRIPTION
## Summary
- avoid sharing satellite dictionaries across `GraphData` instances by using `field(default_factory=...)`
- re-export `CurveData` and `GraphData` in `core.__init__`
- test that changes to one instance's satellite dictionaries do not affect another

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ef9dd930832d8cbbab7fbbc87316