### PR TITLE
Fix header typo in application coordinator

### DIFF
--- a/ui/application_coordinator.py
+++ b/ui/application_coordinator.py
@@ -1,4 +1,4 @@
-#Application_coordiantor.py
+# application_coordinator.py
 
 from controllers import GraphController
 from ui.GraphCurvePanel import GraphCurvePanel


### PR DESCRIPTION
## Summary
- correct misspelled header in `ui/application_coordinator.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849ef81e5e8832dbdefc0bbe0c52125