### PR TITLE
Fix typo in import_project_from_json docstring

### DIFF
--- a/project_io.py
+++ b/project_io.py
@@ -10,7 +10,7 @@ def export_project_to_json(graphs: Dict[str, GraphData], path: str):
         json.dump(project_to_dict(graphs), f, indent=2)
 
 def import_project_from_json(path: str) -> Dict[str, GraphData]:
-    """Imprte un projet (ensemble de graphiques) depuis un fichier JSON."""
+    """Importe un projet (ensemble de graphiques) depuis un fichier JSON."""
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
     return dict_to_project(data)


### PR DESCRIPTION
## Summary
- fix spelling in project import docstring

## Testing
- `python -m py_compile project_io.py`

------
https://chatgpt.com/codex/tasks/task_e_6849eea6a4ac832d9c8b266bc6a242af