### PR TITLE
Pass AppState & SignalBus as dependencies

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -3,13 +3,15 @@
 from core.app_state import AppState
 from core.graph_service import GraphService
 from ui.graph_ui_coordinator import GraphUICoordinator
+from signal_bus import SignalBus, signal_bus
 
 class GraphController:
-    def __init__(self, views: dict, central_area):
+    def __init__(self, state: AppState, bus: SignalBus, views: dict, central_area):
         print("🧠 [GraphController.__init__] Initialisation du contrôleur")
-        self.state = AppState.get_instance()
-        self.service = GraphService(self.state)
-        self.ui = GraphUICoordinator(self.state, views, central_area)
+        self.state = state
+        self.bus = bus
+        self.service = GraphService(self.state, self.bus)
+        self.ui = GraphUICoordinator(self.state, views, central_area, self.bus)
 
     def load_project(self, graphs: dict):
         print("📂 [GraphController.load_project] Chargement du projet...")

--- a/core/app.py
+++ b/core/app.py
@@ -5,12 +5,16 @@ from ui.ui_main_window import MainWindow
 from layout_manager import get_default_layout, load_layout
 import sys
 from ui.application_coordinator import ApplicationCoordinator
+from core.app_state import AppState
+from signal_bus import SignalBus, signal_bus
 
-def launch_app():
-    window = MainWindow()
+def launch_app(state: AppState = None, bus: SignalBus = signal_bus):
+    state = state or AppState.get_instance()
+    bus = bus or signal_bus
+    window = MainWindow(state, bus)
 
     # Coordination de l'application
-    app_coordinator = ApplicationCoordinator(window)
+    app_coordinator = ApplicationCoordinator(window, state, bus)
 
     # Connecte la zone centrale de tracé
     window.center_area_widget = app_coordinator.center_area

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -2,7 +2,7 @@
 
 from core.app_state import AppState
 from core.models import GraphData, CurveData
-from signal_bus import signal_bus
+from signal_bus import SignalBus, signal_bus
 from core.utils.naming import get_next_graph_name
 
 
@@ -12,9 +12,10 @@ class GraphService:
     indépendamment de l'interface utilisateur.
     """
 
-    def __init__(self, state: AppState):
+    def __init__(self, state: AppState, bus: SignalBus = signal_bus):
         print("🧠 [GraphService.__init__] Initialisation du service avec AppState")
         self.state = state
+        self.bus = bus
 
     def create_graph(self):
         print("🧱 [GraphService.create_graph] Création d'un nouveau graphique...")
@@ -41,7 +42,7 @@ class GraphService:
         self.state.select_graph(name)
         print(f"🎯 [GraphService.select_graph] Graphique sélectionné : {self.state.current_graph.name if self.state.current_graph else 'None'}")
         print(f"📢 [GraphService.select_graph] Emission du signal graph_selected")
-        #signal_bus.graph_selected.emit(name)
+        # self.bus.graph_selected.emit(name)
     
     def select_curve(self, curve_name: str):
         print(f"🖱 [GraphService.select_curve] Sélection de la courbe : {curve_name}")
@@ -75,7 +76,7 @@ class GraphService:
         print(f"📥 [GraphService.add_graph] Appel avec nom = {name}")
     
         if not name or name.strip() == "":
-            name = get_next_graph_name()
+            name = get_next_graph_name(self.state)
             print(f"🆕 [GraphService.add_graph] Nom généré automatiquement : {name}")
         else:
             print(f"🏷️ [GraphService.add_graph] Nom spécifié : {name}")
@@ -94,10 +95,10 @@ class GraphService:
         
         # 👇 Signaler qu’un graphique a été sélectionné (utile pour afficher les propriétés)
         print(f"📢 [GraphService.add_graph] Emission du signal graph_selected pour '{name}'")
-        signal_bus.graph_selected.emit(name)
-    
+        self.bus.graph_selected.emit(name)
+
         print(f"📢 [GraphService.add_graph] Emission du signal graph_updated")
-        signal_bus.graph_updated.emit()
+        self.bus.graph_updated.emit()
 
 
     def add_curve(self, graph_name: str, curve: CurveData = None):
@@ -132,11 +133,11 @@ class GraphService:
     
         # 👇 Sélectionne automatiquement la courbe ajoutée
         print(f"📢 [GraphService.add_curve] Emission du signal curve_selected pour '{curve.name}' dans '{graph.name}'")
-        signal_bus.curve_selected.emit(graph.name, curve.name)
-    
+        self.bus.curve_selected.emit(graph.name, curve.name)
+
         print(f"📢 [GraphService.add_curve] Emission des signaux curve_list_updated et curve_updated")
-        signal_bus.curve_list_updated.emit()
-        signal_bus.curve_updated.emit()
+        self.bus.curve_list_updated.emit()
+        self.bus.curve_updated.emit()
             
 
     def remove_graph(self, name: str):
@@ -152,7 +153,7 @@ class GraphService:
             self.state.current_curve = None
             
         print(f"📢 [GraphService.remove_graph] Emission du signal graph_updated")
-        signal_bus.graph_updated.emit()
+        self.bus.graph_updated.emit()
 
             
     def remove_curve(self, curve_name: str):
@@ -174,7 +175,7 @@ class GraphService:
     
         print(f"✅ [GraphService.remove_curve] Courbe '{curve_name}' supprimée.")
         print(f"📢 [GraphService.remove_curve] Emission du signal curve_updated")
-        signal_bus.curve_updated.emit()
+        self.bus.curve_updated.emit()
 
 
     def import_graph(self, graph_data: GraphData):

--- a/core/startup.py
+++ b/core/startup.py
@@ -3,25 +3,27 @@ from core.app_state import AppState
 from controllers import GraphController
 from core.graph_service import GraphService
 from ui.graph_ui_coordinator import GraphUICoordinator
+from signal_bus import SignalBus, signal_bus
 from datetime import datetime
 import sys
 from PyQt5 import QtWidgets
 
-def initialize_application(center_area_widget):
-    state = AppState.get_instance()
+def initialize_application(center_area_widget, state: AppState = None, bus: SignalBus = signal_bus):
+    state = state or AppState.get_instance()
+    bus = bus or signal_bus
     default_graph_name = "Graphique"
-    graph_service = GraphService(state)
+    graph_service = GraphService(state, bus)
     graph_service.add_graph(default_graph_name)
     
     # Prépare les vues associées
     from ui.views import MyPlotView
     
     graph = state.graphs[default_graph_name]
-    plot_view = MyPlotView(graph)
+    plot_view = MyPlotView(graph, bus)
     center_area_widget.add_plot_widget(plot_view.plot_widget)
     
     views = {default_graph_name: plot_view}
-    controller = GraphController(views)
+    controller = GraphController(state, bus, views, center_area_widget)
 
     return controller, plot_view
 

--- a/core/utils/naming.py
+++ b/core/utils/naming.py
@@ -2,9 +2,10 @@
 
 from core.app_state import AppState
 
-def get_next_graph_name():
+
+def get_next_graph_name(state: AppState) -> str:
+    """Return a unique graph name based on the current content of *state*."""
     print("🔍 [get_next_graph_name] Début de génération de nom...")
-    state = AppState.get_instance()
 
     if not state.graphs:
         print("📭 Aucun graphique existant, on commence à Graphique 1")

--- a/main.py
+++ b/main.py
@@ -4,8 +4,12 @@ from PyQt5 import QtWidgets
 from core.startup import check_expiry_date
 from core.app import launch_app
 import sys
+from signal_bus import SignalBus, signal_bus
+from core.app_state import AppState
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     check_expiry_date()
-    launch_app()
+    state = AppState.get_instance()
+    bus = signal_bus
+    launch_app(state, bus)

--- a/plot_container.py
+++ b/plot_container.py
@@ -1,11 +1,11 @@
 #plot_container.py
 
 from PyQt5 import QtWidgets
-from signal_bus import signal_bus
+from signal_bus import SignalBus, signal_bus
 from AdvancedPlotContainer import AdvancedPlotContainer
 
 class PlotContainerWidget(QtWidgets.QGroupBox):
-    def __init__(self, graph_name, plot_widget, parent=None):
+    def __init__(self, graph_name, plot_widget, bus: SignalBus = signal_bus, parent=None):
         print("[plot_container.py > __init__()] ▶️ Entrée dans __init__()")
 
         super().__init__(graph_name, parent)
@@ -17,6 +17,7 @@ class PlotContainerWidget(QtWidgets.QGroupBox):
 
         self.plot_widget = plot_widget  # garde pour compatibilité
         self.graph_name = graph_name
+        self.bus = bus
         self.removed = False
         
         # Forcer taille minimale pour laisser place aux satellites
@@ -38,7 +39,7 @@ class PlotContainerWidget(QtWidgets.QGroupBox):
         print("[plot_container.py > mousePressEvent()] ▶️ Entrée dans mousePressEvent()")
 
         if not self.removed:
-            signal_bus.graph_selected.emit(self.graph_name)
+            self.bus.graph_selected.emit(self.graph_name)
         super().mousePressEvent(event)
     
     def set_selected(self, selected: bool):

--- a/ui/PropertiesPanel.py
+++ b/ui/PropertiesPanel.py
@@ -5,10 +5,11 @@ from PyQt5 import QtWidgets, QtCore, QtGui
 
 class PropertiesPanel(QtWidgets.QTabWidget):
 
-    def __init__(self, parent=None):
+    def __init__(self, state: AppState, parent=None):
         print("[PropertiesPanel.py > __init__()] ▶️ Entrée dans __init__()")
 
         super().__init__(parent)
+        self.state = state
         self.setup_ui()
 
     def setup_ui(self):
@@ -242,7 +243,7 @@ class PropertiesPanel(QtWidgets.QTabWidget):
 
     def update_graph_ui(self):
         """Met à jour les champs de l'onglet graphique en fonction du graphique sélectionné."""
-        state = AppState.get_instance()
+        state = self.state
         graph = state.current_graph
         if not graph:
             print("[PropertiesPanel] ⚠️ Aucun graphique sélectionné")
@@ -296,7 +297,7 @@ class PropertiesPanel(QtWidgets.QTabWidget):
 
     def update_curve_ui(self):
         """Met à jour les champs de l'onglet courbe en fonction de la courbe sélectionnée."""
-        state = AppState.get_instance()
+        state = self.state
         curve = state.current_curve
         if not curve:
             print("[PropertiesPanel] ⚠️ Aucune courbe sélectionnée")

--- a/ui/graph_ui_coordinator.py
+++ b/ui/graph_ui_coordinator.py
@@ -3,14 +3,16 @@
 from core.app_state import AppState
 from ui.views import MyPlotView
 from ui.PropertiesPanel import PropertiesPanel
+from signal_bus import SignalBus, signal_bus
 
 
 class GraphUICoordinator:
-    def __init__(self, state: AppState, views: dict, central_area):
+    def __init__(self, state: AppState, views: dict, central_area, bus: SignalBus = signal_bus):
         print("[GraphUICoordinator.__init__] Initialisation")
         self.state = state
         self.views = views
         self.central_area = central_area  # 🆕 pour gérer dynamiquement les widgets
+        self.bus = bus
         print(f"[GraphUICoordinator.__init__] Vues disponibles : {list(self.views.keys())}")
         
     def refresh_curve_ui(self):
@@ -33,7 +35,7 @@ class GraphUICoordinator:
             print(f"📌 [refresh_plot] Vérification de la vue pour : {name}")
             if name not in self.views:
                 print(f"🆕 [refresh_plot] Création de la vue pour le graphique : {name}")
-                view = MyPlotView(graph)
+                view = MyPlotView(graph, self.bus)
                 self.views[name] = view
                 if self.central_area:
                     print(f"📤 [refresh_plot] Tentative d’ajout du widget à la zone centrale")

--- a/ui/views.py
+++ b/ui/views.py
@@ -1,16 +1,16 @@
-from core.app_state import AppState
 from PyQt5 import QtWidgets, QtCore
 from PyQt5.QtCore import QTimer
 import time
 import pyqtgraph as pg
-from signal_bus import signal_bus
+from signal_bus import SignalBus, signal_bus
 from PyQt5.QtGui import QColor
     
 class MyPlotView:
-    def __init__(self, graph_data):
+    def __init__(self, graph_data, bus: SignalBus = signal_bus):
         print("[views.py > __init__()] ▶️ Entrée dans __init__()")
 
         self.graph_data = graph_data
+        self.bus = bus
         self.plot_widget = pg.PlotWidget()
         self.plot_widget.setBackground('w')
         self.plot_widget.useOpenGL(True)
@@ -161,7 +161,7 @@ class MyPlotView:
 
         if selected_curve:
             print(f"[CLICK] Courbe cliquée (par distance) : {selected_curve}")
-            signal_bus.curve_selected.emit(self.graph_data.name, selected_curve)
+            self.bus.curve_selected.emit(self.graph_data.name, selected_curve)
 
     def _format_axis(self, axis, unit: str, fmt: str):
         print("[views.py > _format_axis()] ▶️ Entrée dans _format_axis()")


### PR DESCRIPTION
## Summary
- inject `AppState` and `SignalBus` in constructors instead of using globals
- update factories and entrypoints to create default instances
- propagate the objects throughout the UI components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f3455acc832dbe4f7784a9373384