### PR TITLE
Implement reset zoom hookup

### DIFF
--- a/tests/test_graph_controller.py
+++ b/tests/test_graph_controller.py
@@ -87,3 +87,17 @@ def test_controller_rename_operations(controller):
     c.select_graph("RenamedGraph")
     c.rename_curve("Courbe 1", "C1")
     assert state.current_graph.curves[0].name == "C1"
+
+
+def test_controller_reset_zoom_invokes_ui(controller):
+    c, state, _ = controller
+
+    called = {"count": 0}
+
+    def stub():
+        called["count"] += 1
+
+    c.ui.reset_zoom = stub
+    c.reset_zoom()
+
+    assert called["count"] == 1

--- a/ui/application_coordinator.py
+++ b/ui/application_coordinator.py
@@ -63,6 +63,11 @@ class ApplicationCoordinator:
         signal_bus.curve_selected.connect(self._on_curve_selected)
         signal_bus.graph_selected.connect(self._on_graph_selected)
 
+        # 🔍 Réinitialisation du zoom depuis le panneau de propriétés
+        self.properties_panel.button_reset_zoom.clicked.connect(
+            self.controller.reset_zoom
+        )
+
     def _handle_add_requested(self, kind_or_graphname):
         if kind_or_graphname == "graph":
             self.controller.add_graph(None)


### PR DESCRIPTION
## Summary
- connect the reset zoom button to `controller.reset_zoom`
- test that controller calls its UI on reset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f98394a8832d90c42649a039735e