### PR TITLE
Implement visibility toggling via controller

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -94,6 +94,20 @@ class GraphController:
         self.service.bring_curve_to_front()
         self.ui.refresh_plot()
 
+    def set_graph_visible(self, graph_name: str, visible: bool):
+        logger.debug(f"👁 [GraphController.set_graph_visible] {graph_name} → {visible}")
+        self.service.set_graph_visible(graph_name, visible)
+        signal_bus.graph_updated.emit()
+        signal_bus.curve_updated.emit()
+        self.ui.refresh_plot()
+
+    def set_curve_visible(self, graph_name: str, curve_name: str, visible: bool):
+        logger.debug(f"👁 [GraphController.set_curve_visible] {curve_name} in {graph_name} → {visible}")
+        self.service.set_curve_visible(graph_name, curve_name, visible)
+        signal_bus.graph_updated.emit()
+        signal_bus.curve_updated.emit()
+        self.ui.refresh_plot()
+
     def set_opacity(self, value: float):
         logger.debug(f"🎨 [GraphController.set_opacity] Opacité = {value}")
         self.service.set_opacity(value)

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -236,3 +236,19 @@ class GraphService:
         logger.debug(f"👁 [GraphService.set_show_label] Étiquette visible = {visible}")
         if self.state.current_curve:
             self.state.current_curve.show_label = visible
+
+    def set_graph_visible(self, graph_name: str, visible: bool):
+        logger.debug(f"👁 [GraphService.set_graph_visible] {graph_name} → {visible}")
+        graph = self.state.graphs.get(graph_name)
+        if graph:
+            graph.visible = visible
+
+    def set_curve_visible(self, graph_name: str, curve_name: str, visible: bool):
+        logger.debug(f"👁 [GraphService.set_curve_visible] {curve_name} in {graph_name} → {visible}")
+        graph = self.state.graphs.get(graph_name)
+        if not graph:
+            return
+        for curve in graph.curves:
+            if curve.name == curve_name:
+                curve.visible = visible
+                break

--- a/signal_bus.py
+++ b/signal_bus.py
@@ -8,6 +8,10 @@ class SignalBus(QtCore.QObject):
     curve_updated = QtCore.pyqtSignal()
     graph_updated = QtCore.pyqtSignal()
 
+    # Visible state toggles
+    graph_visibility_changed = QtCore.pyqtSignal(str, bool)
+    curve_visibility_changed = QtCore.pyqtSignal(str, str, bool)
+
     remove_requested = QtCore.pyqtSignal(str, str)
     rename_requested = QtCore.pyqtSignal(str, str, str)  # kind, old_name, new_name
 

--- a/tests/test_graph_controller.py
+++ b/tests/test_graph_controller.py
@@ -22,6 +22,8 @@ def make_signal_bus():
         curve_list_updated=DummySignal(),
         curve_updated=DummySignal(),
         graph_updated=DummySignal(),
+        graph_visibility_changed=DummySignal(),
+        curve_visibility_changed=DummySignal(),
     )
 
 class DummyCoordinator:
@@ -101,3 +103,24 @@ def test_controller_reset_zoom_invokes_ui(controller):
     c.reset_zoom()
 
     assert called["count"] == 1
+
+
+def test_controller_set_visibility(controller):
+    c, state, bus = controller
+    c.add_graph()
+    graph = list(state.graphs.keys())[0]
+    c.add_curve(graph)
+
+    bus.graph_updated.emitted.clear()
+    bus.curve_updated.emitted.clear()
+    c.set_graph_visible(graph, False)
+    assert state.graphs[graph].visible is False
+    assert len(bus.graph_updated.emitted) == 1
+    assert len(bus.curve_updated.emitted) == 1
+
+    bus.graph_updated.emitted.clear()
+    bus.curve_updated.emitted.clear()
+    c.set_curve_visible(graph, "Courbe 1", False)
+    assert state.graphs[graph].curves[0].visible is False
+    assert len(bus.graph_updated.emitted) == 1
+    assert len(bus.curve_updated.emitted) == 1

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -58,3 +58,16 @@ def test_rename_graph_and_curve(service):
     svc.select_graph("NewGraph")
     svc.rename_curve("Courbe 1", "Renamed")
     assert state.current_graph.curves[0].name == "Renamed"
+
+
+def test_set_visibility(service):
+    svc, state, _ = service
+    svc.add_graph()
+    graph = list(state.graphs.keys())[0]
+    svc.add_curve(graph, curve=CurveData(name="tmp", x=[0], y=[0]))
+
+    svc.set_graph_visible(graph, False)
+    assert state.graphs[graph].visible is False
+
+    svc.set_curve_visible(graph, "Courbe 1", False)
+    assert state.graphs[graph].curves[0].visible is False

--- a/ui/GraphCurvePanel.py
+++ b/ui/GraphCurvePanel.py
@@ -65,10 +65,15 @@ class CombinedDelegate(QStyledItemDelegate):
     
             if eye_rect.contains(pos) and kind in ("graph", "curve"):
                 val = index.data(Qt.UserRole + 1)
-                logger.debug(f"👁️ [Toggle Visibility] {name} → {not val}")
-                model.setData(index, not val, Qt.UserRole + 1)
-                signal_bus.curve_updated.emit()
-                signal_bus.graph_updated.emit()
+                new_val = not val
+                logger.debug(f"👁️ [Toggle Visibility] {name} → {new_val}")
+                model.setData(index, new_val, Qt.UserRole + 1)
+                if kind == "graph":
+                    signal_bus.graph_visibility_changed.emit(name, new_val)
+                else:
+                    parent_index = index.parent()
+                    graph_name = parent_index.data(Qt.UserRole + 4) if parent_index.isValid() else None
+                    signal_bus.curve_visibility_changed.emit(graph_name, name, new_val)
                 return True
     
             if delete_rect.contains(pos) and kind in ("graph", "curve"):

--- a/ui/application_coordinator.py
+++ b/ui/application_coordinator.py
@@ -64,6 +64,8 @@ class ApplicationCoordinator:
         signal_bus.graph_selected.connect(self._on_graph_selected)
         signal_bus.rename_requested.connect(self._handle_rename_requested)
         signal_bus.remove_requested.connect(self._handle_remove_requested)
+        signal_bus.graph_visibility_changed.connect(self.controller.set_graph_visible)
+        signal_bus.curve_visibility_changed.connect(self.controller.set_curve_visible)
 
         # 🔍 Réinitialisation du zoom depuis le panneau de propriétés
         self.properties_panel.button_reset_zoom.clicked.connect(


### PR DESCRIPTION
## Summary
- allow CombinedDelegate to emit new visibility signals when clicking the eye icon
- route new signals in ApplicationCoordinator to the controller
- add `set_graph_visible` and `set_curve_visible` to controller and service
- provide new signals in `signal_bus`
- test new visibility methods

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afbebc8f4832da6c5d0a3aa015591