### PR TITLE
Improve selection logging and add test

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -55,11 +55,17 @@ class GraphController:
     def select_graph(self, name: str):
         logger.debug(f"🎯 [GraphController.select_graph] Sélection du graphique : {name}")
         self.service.select_graph(name)
+        logger.debug(
+            f"   ➡️ Graphique courant : {self.state.current_graph.name if self.state.current_graph else 'None'}"
+        )
         self.ui.refresh_plot()
 
     def select_curve(self, curve_name: str):
         logger.debug(f"🎯 [GraphController.select_curve] Sélection de la courbe : {curve_name}")
         self.service.select_curve(curve_name)
+        logger.debug(
+            f"   ➡️ Courbe courante : {self.state.current_curve.name if self.state.current_curve else 'None'}"
+        )
         self.ui.refresh_curve_ui()
 
     def remove_graph(self, name: str):

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -37,6 +37,9 @@ class GraphService:
     def select_curve(self, curve_name: str):
         logger.debug(f"🖱 [GraphService.select_curve] Sélection de la courbe : {curve_name}")
         self.state.select_curve(curve_name)
+        logger.debug(
+            f"🔎 [GraphService.select_curve] Courbe active : {self.state.current_curve.name if self.state.current_curve else 'None'}"
+        )
 
     def rename_graph(self, old_name: str, new_name: str):
         logger.debug(f"✏️ [GraphService.rename_graph] Renommage du graphique : {old_name} → {new_name}")

--- a/tests/test_graph_controller.py
+++ b/tests/test_graph_controller.py
@@ -140,3 +140,22 @@ def test_controller_graph_options(controller):
     c.set_grid_visible(True)
     assert state.graphs[graph].grid_visible is True
     assert len(bus.graph_updated.emitted) == 1
+
+
+def test_selection_flow_updates_state_and_ui(controller):
+    c, state, bus = controller
+    c.add_graph()
+    graph_name = list(state.graphs.keys())[0]
+
+    bus.curve_selected.emitted.clear()
+    c.add_curve(graph_name)
+
+    assert state.current_graph.name == graph_name
+    assert state.current_curve.name == "Courbe 1"
+    assert bus.curve_selected.emitted[0] == (graph_name, "Courbe 1")
+
+    c.ui.curve_calls = 0
+    c.select_curve("Courbe 1")
+
+    assert state.current_curve.name == "Courbe 1"
+    assert c.ui.curve_calls == 1


### PR DESCRIPTION
## Summary
- log active graph and curve in selection helpers
- log currently selected curve after GraphService selects it
- test end-to-end selection workflow for GraphController

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4a088810832d9c2b5795af344b2c