### PR TITLE
Reset curve tab when no selection

### DIFF
--- a/tests/test_properties_panel.py
+++ b/tests/test_properties_panel.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5 import QtWidgets
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.app_state import AppState
+from core.models import GraphData, CurveData
+from ui.PropertiesPanel import PropertiesPanel
+
+
+def test_update_curve_ui_resets_when_no_selection():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    AppState._instance = None
+    state = AppState.get_instance()
+
+    graph = GraphData(name="g")
+    curve = CurveData(name="c1", x=[0], y=[0])
+    graph.add_curve(curve)
+
+    state.graphs["g"] = graph
+    state.current_graph = graph
+    state.current_curve = curve
+
+    panel = PropertiesPanel()
+    panel.update_curve_ui()
+    assert panel.label_curve_name.text() == "c1"
+
+    state.current_curve = None
+    panel.update_curve_ui()
+
+    assert panel.label_curve_name.text() == "—"
+    assert panel.display_mode_combo.currentIndex() == 0
+    assert not panel.downsampling_ratio_input.isEnabled()
+    assert not panel.downsampling_apply_btn.isEnabled()

--- a/ui/PropertiesPanel.py
+++ b/ui/PropertiesPanel.py
@@ -380,6 +380,22 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         curve = state.current_curve
         if not curve:
             logger.debug("[PropertiesPanel] ⚠️ Aucune courbe sélectionnée")
+            self.label_curve_name.setText("—")
+            self.color_button.setStyleSheet("")
+            self.style_combo.setCurrentIndex(0)
+            self.width_spin.setValue(1)
+            self.symbol_combo.setCurrentIndex(0)
+            self.display_mode_combo.setCurrentIndex(0)
+            self.label_mode_combo.setCurrentIndex(0)
+            self.opacity_slider.setValue(100)
+            self.fill_checkbox.setChecked(False)
+            self.gain_slider.setValue(100)
+            self.offset_slider.setValue(0)
+            self.zero_indicator_combo.setCurrentIndex(0)
+            self.downsampling_combo.setCurrentIndex(0)
+            self.downsampling_ratio_input.setValue(10)
+            self.downsampling_ratio_input.setEnabled(False)
+            self.downsampling_apply_btn.setEnabled(False)
             return
     
         logger.debug(f"[PropertiesPanel] 🔄 Mise à jour des champs pour la courbe '{curve.name}'")

--- a/ui/graph_ui_coordinator.py
+++ b/ui/graph_ui_coordinator.py
@@ -21,10 +21,11 @@ class GraphUICoordinator:
         logger.debug("[graph_ui_coordinator > refresh_curve_ui()] ▶️ Rafraîchissement des propriétés de courbe")
         if self.state.current_curve:
             logger.debug(f"🔍 Courbe courante : {self.state.current_curve.name}")
-            if self.properties_panel:
-                self.properties_panel.update_curve_ui()
         else:
             logger.debug("ℹ️ Aucune courbe sélectionnée")
+
+        if self.properties_panel:
+            self.properties_panel.update_curve_ui()
 
     def refresh_plot(self):
         logger.debug("\n[GraphUICoordinator.refresh_plot] ▶️ Début du rafraîchissement des graphes")


### PR DESCRIPTION
## Summary
- clear curve widgets if there is no current curve
- always trigger `update_curve_ui()` from coordinator
- test `update_curve_ui` resets the UI when `current_curve` is `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b52658c7c832da017a4225b8958f1