### PR TITLE
Add downsampling controls

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -202,6 +202,16 @@ class GraphController:
         self.service.set_show_label(visible)
         self.ui.refresh_curve_ui()
 
+    def set_downsampling_mode(self, mode: str):
+        logger.debug(f"📉 [GraphController.set_downsampling_mode] Mode = {mode}")
+        self.service.set_downsampling_mode(mode)
+        self.ui.refresh_curve_ui()
+
+    def set_downsampling_ratio(self, ratio: int):
+        logger.debug(f"📉 [GraphController.set_downsampling_ratio] Ratio = {ratio}")
+        self.service.set_downsampling_ratio(ratio)
+        self.ui.refresh_curve_ui()
+
     def reset_zoom(self):
         logger.debug("🔍 [GraphController.reset_zoom] Réinitialisation du zoom")
         self.ui.reset_zoom()

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -260,6 +260,16 @@ class GraphService:
         if self.state.current_curve:
             self.state.current_curve.show_label = visible
 
+    def set_downsampling_mode(self, mode: str):
+        logger.debug(f"📉 [GraphService.set_downsampling_mode] Mode = {mode}")
+        if self.state.current_curve:
+            self.state.current_curve.downsampling_mode = mode
+
+    def set_downsampling_ratio(self, ratio: int):
+        logger.debug(f"📉 [GraphService.set_downsampling_ratio] Ratio = {ratio}")
+        if self.state.current_curve:
+            self.state.current_curve.downsampling_ratio = ratio
+
     def set_graph_visible(self, graph_name: str, visible: bool):
         logger.debug(f"👁 [GraphService.set_graph_visible] {graph_name} → {visible}")
         graph = self.state.graphs.get(graph_name)

--- a/tests/test_graph_controller.py
+++ b/tests/test_graph_controller.py
@@ -159,3 +159,16 @@ def test_selection_flow_updates_state_and_ui(controller):
 
     assert state.current_curve.name == "Courbe 1"
     assert c.ui.curve_calls == 1
+
+
+def test_downsampling_settings(controller):
+    c, state, _ = controller
+    c.add_graph()
+    graph_name = list(state.graphs.keys())[0]
+    c.add_curve(graph_name)
+
+    c.set_downsampling_mode("manual")
+    assert state.current_curve.downsampling_mode == "manual"
+
+    c.set_downsampling_ratio(7)
+    assert state.current_curve.downsampling_ratio == 7

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -87,3 +87,16 @@ def test_graph_options(service):
     assert state.current_graph.grid_visible is True
     assert state.current_graph.log_x is True
     assert state.current_graph.log_y is True
+
+
+def test_downsampling_settings(service):
+    svc, state, _ = service
+    svc.add_graph()
+    graph = list(state.graphs.keys())[0]
+    svc.add_curve(graph, curve=CurveData(name="tmp", x=[0, 1], y=[0, 1]))
+
+    svc.set_downsampling_mode("manual")
+    svc.set_downsampling_ratio(5)
+
+    assert state.current_curve.downsampling_mode == "manual"
+    assert state.current_curve.downsampling_ratio == 5

--- a/tests/test_properties_panel.py
+++ b/tests/test_properties_panel.py
@@ -27,6 +27,7 @@ def test_update_curve_ui_resets_when_no_selection():
     state.current_curve = curve
 
     panel = PropertiesPanel()
+    panel.setTabEnabled(1, True)
     panel.update_curve_ui()
     assert panel.label_curve_name.text() == "c1"
 
@@ -37,3 +38,26 @@ def test_update_curve_ui_resets_when_no_selection():
     assert panel.display_mode_combo.currentIndex() == 0
     assert not panel.downsampling_ratio_input.isEnabled()
     assert not panel.downsampling_apply_btn.isEnabled()
+
+
+def test_update_curve_ui_manual_enables_ratio():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    AppState._instance = None
+    state = AppState.get_instance()
+
+    graph = GraphData(name="g")
+    curve = CurveData(name="c1", x=[0], y=[0], downsampling_mode="manual", downsampling_ratio=4)
+    graph.add_curve(curve)
+
+    state.graphs["g"] = graph
+    state.current_graph = graph
+    state.current_curve = curve
+
+    panel = PropertiesPanel()
+    panel.setTabEnabled(1, True)
+    panel.update_curve_ui()
+
+    assert panel.downsampling_combo.currentData() == "manual"
+    assert panel.downsampling_ratio_input.isEnabled()
+    assert panel.downsampling_apply_btn.isEnabled()

--- a/ui/PropertiesPanel.py
+++ b/ui/PropertiesPanel.py
@@ -55,6 +55,18 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         self.opacity_slider.valueChanged.connect(
             lambda v: self._call_controller(self.controller.set_opacity, float(v))
         )
+        self.downsampling_combo.currentIndexChanged.connect(
+            lambda i: self._call_controller(
+                self.controller.set_downsampling_mode,
+                self.downsampling_combo.itemData(i),
+            )
+        )
+        self.downsampling_apply_btn.clicked.connect(
+            lambda: self._call_controller(
+                self.controller.set_downsampling_ratio,
+                int(self.downsampling_ratio_input.value()),
+            )
+        )
         self.bring_to_front_button.clicked.connect(
             lambda: self._call_controller(self.controller.bring_curve_to_front)
         )


### PR DESCRIPTION
## Summary
- support updating downsampling mode and ratio through service and controller
- wire PropertiesPanel widgets to new controller methods
- enable ratio widgets when manual mode is selected
- test persistence of downsampling settings

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd3b06760832d810c4332a0709304