### PR TITLE
Add time offset option

### DIFF
--- a/IO_dossier/serializers.py
+++ b/IO_dossier/serializers.py
@@ -20,6 +20,7 @@ def curve_to_dict(curve: CurveData) -> dict:
         "display_mode": curve.display_mode,
         "gain": curve.gain,
         "offset": curve.offset,
+        "time_offset": curve.time_offset,
         "show_zero_line": curve.show_zero_line,
         "label_mode": curve.label_mode,
         "zero_indicator": curve.zero_indicator
@@ -43,6 +44,7 @@ def dict_to_curve(data: dict) -> CurveData:
         display_mode=data.get("display_mode", "line"),
         gain=data.get("gain", 1.0),
         offset=data.get("offset", 0.0),
+        time_offset=data.get("time_offset", 0.0),
         show_zero_line=data.get("show_zero_line", False),
         show_label=data.get("show_label", False),
         label_mode=data.get("label_mode", "none"),

--- a/controllers.py
+++ b/controllers.py
@@ -206,6 +206,11 @@ class GraphController:
         self.service.set_offset(value)
         self.ui.refresh_curve_ui()
 
+    def set_time_offset(self, value: float):
+        logger.debug(f"⏱ [GraphController.set_time_offset] Time offset = {value}")
+        self.service.set_time_offset(value)
+        self.ui.refresh_curve_ui()
+
     def set_width(self, value: int):
         logger.debug(f"📏 [GraphController.set_width] Width = {value}")
         self.service.set_width(value)

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -221,6 +221,11 @@ class GraphService:
         if self.state.current_curve:
             self.state.current_curve.offset = value
 
+    def set_time_offset(self, value: float):
+        logger.debug(f"⏱ [GraphService.set_time_offset] Time offset = {value}")
+        if self.state.current_curve:
+            self.state.current_curve.time_offset = value
+
     def set_width(self, value: int):
         logger.debug(f"📏 [GraphService.set_width] Width = {value}")
         if self.state.current_curve:

--- a/core/models.py
+++ b/core/models.py
@@ -21,6 +21,7 @@ class CurveData:
     display_mode: str = "line"  # 'line', 'scatter', 'bar'
     gain: float = 1.0
     offset: float = 0.0
+    time_offset: float = 0.0
     zero_indicator: str = "none"  # "none", "line"
     label_mode: str = "none"  # valeurs possibles : "none", "inline", "legend"
 

--- a/tests/test_graph_controller.py
+++ b/tests/test_graph_controller.py
@@ -169,3 +169,13 @@ def test_set_width_updates_curve(controller):
 
     c.set_width(5)
     assert state.current_curve.width == 5
+
+
+def test_set_time_offset_updates_curve(controller):
+    c, state, _ = controller
+    c.add_graph()
+    graph_name = list(state.graphs.keys())[0]
+    c.add_curve(graph_name)
+
+    c.set_time_offset(3.0)
+    assert state.current_curve.time_offset == 3.0

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -110,3 +110,13 @@ def test_axis_settings(service):
     assert g.fix_y_range is True
     assert g.y_min == -1
     assert g.y_max == 1
+
+
+def test_set_time_offset(service):
+    svc, state, _ = service
+    svc.add_graph()
+    graph = list(state.graphs.keys())[0]
+    svc.add_curve(graph, curve=CurveData(name="tmp", x=[0], y=[0]))
+
+    svc.set_time_offset(2.5)
+    assert state.current_curve.time_offset == 2.5

--- a/tests/test_properties_panel.py
+++ b/tests/test_properties_panel.py
@@ -37,3 +37,4 @@ def test_update_curve_ui_resets_when_no_selection():
     assert panel.display_mode_combo.currentIndex() == 0
     assert not panel.downsampling_ratio_input.isEnabled()
     assert not panel.downsampling_apply_btn.isEnabled()
+    assert panel.time_offset_input.value() == 0.0

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -15,7 +15,7 @@ from IO_dossier import serializers
 
 
 def create_sample_curve(name="c1"):
-    c = CurveData(name=name, x=[0,1,2], y=[1,2,3])
+    c = CurveData(name=name, x=[0,1,2], y=[1,2,3], time_offset=1.5)
     # attributes expected by serializers but missing in dataclass
     c.show_zero_line = False
     c.show_label = False
@@ -40,6 +40,7 @@ def patch_serializers(monkeypatch):
             display_mode=data.get("display_mode", "line"),
             gain=data.get("gain", 1.0),
             offset=data.get("offset", 0.0),
+            time_offset=data.get("time_offset", 0.0),
             label_mode=data.get("label_mode", "none"),
             zero_indicator=data.get("zero_indicator", "none"),
         )
@@ -60,6 +61,7 @@ def test_curve_serialization(tmp_path):
     assert loaded.name == curve.name
     assert np.array_equal(loaded.x, curve.x)
     assert np.array_equal(loaded.y, curve.y)
+    assert loaded.time_offset == curve.time_offset
 
 
 def test_graph_serialization(tmp_path):
@@ -71,6 +73,7 @@ def test_graph_serialization(tmp_path):
     assert loaded.name == graph.name
     assert len(loaded.curves) == 1
     assert loaded.curves[0].name == graph.curves[0].name
+    assert loaded.curves[0].time_offset == graph.curves[0].time_offset
 
 
 def test_project_serialization(tmp_path):
@@ -85,3 +88,4 @@ def test_project_serialization(tmp_path):
     assert set(loaded.keys()) == {"g1", "g2"}
     assert len(loaded["g1"].curves) == 1
     assert loaded["g1"].curves[0].name == "c1"
+    assert loaded["g1"].curves[0].time_offset == g1.curves[0].time_offset

--- a/ui/PropertiesPanel.py
+++ b/ui/PropertiesPanel.py
@@ -37,6 +37,12 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         self.offset_slider.valueChanged.connect(
             lambda v: self._call_controller(self.controller.set_offset, float(v))
         )
+        self.time_offset_apply_btn.clicked.connect(
+            lambda: self._call_controller(
+                self.controller.set_time_offset,
+                float(self.time_offset_input.value()),
+            )
+        )
         self.style_combo.currentIndexChanged.connect(
             lambda i: self._call_controller(self.controller.set_style, self.style_combo.itemData(i))
         )
@@ -339,6 +345,12 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         self.offset_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
         self.offset_slider.setRange(-500, 500)
         self.offset_slider.setValue(0)
+
+        self.time_offset_input = QtWidgets.QDoubleSpinBox()
+        self.time_offset_input.setRange(-1000.0, 1000.0)
+        self.time_offset_input.setDecimals(3)
+        self.time_offset_input.setSingleStep(0.1)
+        self.time_offset_apply_btn = QtWidgets.QPushButton("Appliquer")
         
         self.zero_indicator_combo = QtWidgets.QComboBox()
         self.zero_indicator_combo.addItem("Aucun", "none")
@@ -350,6 +362,11 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         layout.addWidget(self.gain_slider)
         layout.addWidget(QtWidgets.QLabel("Offset vertical :"))
         layout.addWidget(self.offset_slider)
+        h_time = QtWidgets.QHBoxLayout()
+        h_time.addWidget(QtWidgets.QLabel("Décalage temporel :"))
+        h_time.addWidget(self.time_offset_input)
+        h_time.addWidget(self.time_offset_apply_btn)
+        layout.addLayout(h_time)
         
         self.bring_to_front_button = QtWidgets.QPushButton("🔝 Mettre au premier plan")
         layout.addWidget(self.bring_to_front_button)
@@ -463,6 +480,7 @@ class PropertiesPanel(QtWidgets.QTabWidget):
             self.fill_checkbox.setChecked(False)
             self.gain_slider.setValue(100)
             self.offset_slider.setValue(0)
+            self.time_offset_input.setValue(0.0)
             self.zero_indicator_combo.setCurrentIndex(0)
             self.downsampling_combo.setCurrentIndex(0)
             self.downsampling_ratio_input.setValue(10)
@@ -494,6 +512,7 @@ class PropertiesPanel(QtWidgets.QTabWidget):
     
         self.gain_slider.setValue(int(curve.gain * 100))  # gain 1.0 → slider 100
         self.offset_slider.setValue(int(curve.offset))    # offset en pixels/valeur
+        self.time_offset_input.setValue(curve.time_offset)
     
         index_zero = self.zero_indicator_combo.findData(curve.zero_indicator)
         self.zero_indicator_combo.setCurrentIndex(index_zero if index_zero != -1 else 0)

--- a/ui/views.py
+++ b/ui/views.py
@@ -82,7 +82,8 @@ class MyPlotView:
             if not curve.visible:
                 continue
     
-            x = curve.x[::curve.downsampling_ratio] if curve.downsampling_mode == "manual" else curve.x
+            base_x = curve.x[::curve.downsampling_ratio] if curve.downsampling_mode == "manual" else curve.x
+            x = base_x + curve.time_offset
             y = curve.gain * curve.y + curve.offset
     
             qcolor = QColor(curve.color)


### PR DESCRIPTION
## Summary
- support time offsets in `CurveData`
- handle time offsets in services, controller, UI and views
- allow adjusting the offset from `PropertiesPanel`
- test serialization, controller/service behavior and UI reset

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdbe9cb08832db20826b203b9e613