### PR TITLE
Fix curve foreground ordering

### DIFF
--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -182,7 +182,7 @@ class GraphService:
             return
         if curve in graph.curves:
             graph.curves.remove(curve)
-            graph.curves.insert(0, curve)
+            graph.curves.append(curve)
             logger.debug(f"✅ [GraphService.bring_curve_to_front] Courbe '{curve.name}' déplacée en tête")
 
     # ----- Méthodes métier pour les propriétés du graphique -----

--- a/tests/test_graph_controller.py
+++ b/tests/test_graph_controller.py
@@ -179,3 +179,21 @@ def test_set_time_offset_updates_curve(controller):
 
     c.set_time_offset(3.0)
     assert state.current_curve.time_offset == 3.0
+
+
+def test_bring_curve_to_front_invokes_service_and_refresh(controller):
+    c, state, _ = controller
+    c.add_graph()
+    graph_name = list(state.graphs.keys())[0]
+
+    c.add_curve(graph_name)
+    c.add_curve(graph_name)
+
+    c.select_curve("Courbe 1")
+    c.ui.plot_calls = 0
+
+    c.bring_curve_to_front()
+
+    curves = [curve.name for curve in state.current_graph.curves]
+    assert curves[-1] == "Courbe 1"
+    assert c.ui.plot_calls == 1

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -120,3 +120,18 @@ def test_set_time_offset(service):
 
     svc.set_time_offset(2.5)
     assert state.current_curve.time_offset == 2.5
+
+
+def test_bring_curve_to_front_moves_curve(service):
+    svc, state, _ = service
+    svc.add_graph()
+    graph = list(state.graphs.keys())[0]
+
+    svc.add_curve(graph, curve=CurveData(name="a", x=[0], y=[0]))
+    svc.add_curve(graph, curve=CurveData(name="b", x=[0], y=[0]))
+
+    svc.select_curve("Courbe 1")
+    svc.bring_curve_to_front()
+
+    curves = [c.name for c in state.current_graph.curves]
+    assert curves[-1] == "Courbe 1"


### PR DESCRIPTION
## Summary
- fix `bring_curve_to_front` so selected curve is appended
- test service/controller bring-to-front behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdeea5fe0832db939f5687d613c13