### PR TITLE
Add CSV import utility

### DIFF
--- a/IO_dossier/import_utils.py
+++ b/IO_dossier/import_utils.py
@@ -4,11 +4,40 @@ from typing import List
 from core.models import CurveData
 
 
+def import_curves_from_csv(path: str) -> List[CurveData]:
+    """Import curves from a CSV file.
+
+    The first column is used as the X axis and all subsequent columns are
+    interpreted as Y values for individual curves. Each curve name is taken
+    from the corresponding column header.
+    """
+    df = pd.read_csv(path)
+
+    if df.shape[1] < 2:
+        raise ValueError(
+            "Le fichier doit contenir au moins deux colonnes pour x et y."
+        )
+
+    x_col = df.columns[0]
+    y_cols = df.columns[1:]
+
+    curves = []
+    for col in y_cols:
+        curves.append(
+            CurveData(
+                name=col,
+                x=df[x_col].to_numpy(),
+                y=df[col].to_numpy(),
+            )
+        )
+    return curves
+
+
 def load_curves_from_file(path: str) -> List[CurveData]:
     """Charge des courbes à partir d'un fichier CSV, Excel ou JSON."""
     ext = path.lower().split('.')[-1]
     if ext == "csv":
-        df = pd.read_csv(path)
+        return import_curves_from_csv(path)
     elif ext in ["xls", "xlsx"]:
         df = pd.read_excel(path)
     elif ext == "json":
@@ -24,9 +53,12 @@ def load_curves_from_file(path: str) -> List[CurveData]:
 
     curves = []
     for col in y_cols:
-        curves.append(CurveData(
-            name=col,
-            x=df[x_col].to_numpy(),
-            y=df[col].to_numpy()
-        ))
+        curves.append(
+            CurveData(
+                name=col,
+                x=df[x_col].to_numpy(),
+                y=df[col].to_numpy(),
+            )
+        )
     return curves
+

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from IO_dossier.import_utils import import_curves_from_csv
+
+
+def test_import_curves_from_csv(tmp_path):
+    csv_content = "x,a,b\n0,1,2\n1,3,4\n"
+    path = tmp_path / "data.csv"
+    path.write_text(csv_content)
+
+    curves = import_curves_from_csv(str(path))
+    assert len(curves) == 2
+    assert curves[0].name == "a"
+    assert np.array_equal(curves[0].x, np.array([0,1]))
+    assert np.array_equal(curves[0].y, np.array([1,3]))
+    assert curves[1].name == "b"
+


### PR DESCRIPTION
## Summary
- add `import_curves_from_csv` helper
- use helper in `load_curves_from_file`
- test importing curves from CSV

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be42df12c832d8e7195cbde83740b