### PR TITLE
Handle non-numeric csv values

### DIFF
--- a/IO_dossier/import_utils.py
+++ b/IO_dossier/import_utils.py
@@ -13,6 +13,10 @@ def import_curves_from_csv(path: str) -> List[CurveData]:
     """
     df = pd.read_csv(path)
 
+    # Ensure numeric types for all columns, converting invalid entries to NaN
+    for column in df.columns:
+        df[column] = pd.to_numeric(df[column], errors="coerce")
+
     if df.shape[1] < 2:
         raise ValueError(
             "Le fichier doit contenir au moins deux colonnes pour x et y."

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -19,3 +19,16 @@ def test_import_curves_from_csv(tmp_path):
     assert np.array_equal(curves[0].y, np.array([1,3]))
     assert curves[1].name == "b"
 
+
+def test_import_curves_from_csv_with_non_numeric(tmp_path):
+    """Values that are not numeric should be converted to NaN."""
+    csv_content = "x,a\n0,1\nfoo,3\n"
+    path = tmp_path / "data.csv"
+    path.write_text(csv_content)
+
+    curves = import_curves_from_csv(str(path))
+
+    assert len(curves) == 1
+    assert np.isnan(curves[0].x[1])
+    assert curves[0].y[1] == 3
+


### PR DESCRIPTION
## Summary
- coerce values read from csv files to numeric when importing curves
- test csv import with invalid numeric entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bfd81ede0832d94c093a0b9fda292