### PR TITLE
Add filtering and selection list to curve import dialog

### DIFF
--- a/tests/test_curve_selection_dialog.py
+++ b/tests/test_curve_selection_dialog.py
@@ -1,0 +1,27 @@
+import os
+import sys
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PyQt5 import QtWidgets
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.models import CurveData
+from ui.dialogs.curve_selection_dialog import CurveSelectionDialog
+
+
+def test_filter_and_selection():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    curves = [CurveData(name="temp1", x=[0], y=[0]),
+              CurveData(name="volt2", x=[0], y=[0]),
+              CurveData(name="temp3", x=[0], y=[0])]
+    dlg = CurveSelectionDialog(curves)
+    dlg.filter_edit.setText("temp*")
+    dlg._apply_filter()
+    visible = [not dlg.available_list.item(i).isHidden() for i in range(dlg.available_list.count())]
+    assert visible == [True, False, True]
+
+    dlg.available_list.setCurrentRow(0)
+    dlg._add_selected()
+    selected = dlg.get_selected_curves()
+    assert len(selected) == 1
+    assert selected[0].name == "temp1"

--- a/ui/dialogs/curve_selection_dialog.py
+++ b/ui/dialogs/curve_selection_dialog.py
@@ -1,8 +1,16 @@
 from PyQt5.QtWidgets import (
-    QDialog, QVBoxLayout, QLabel, QListWidget, QListWidgetItem,
-    QDialogButtonBox, QCheckBox
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QDialogButtonBox,
+    QPushButton,
+    QLineEdit,
 )
 from PyQt5.QtCore import Qt
+import fnmatch
 
 from typing import List
 from core.models import CurveData
@@ -15,37 +23,95 @@ class CurveSelectionDialog(QDialog):
     def __init__(self, curves: List[CurveData], parent=None):
         super().__init__(parent)
         self.setWindowTitle("Sélection des courbes à importer")
-        self.resize(400, 300)
+        self.resize(500, 350)
 
         self.curves = curves
-        self.selected_indices = []
 
-        layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Sélectionnez les courbes à importer :"))
+        main_layout = QVBoxLayout(self)
 
-        self.list_widget = QListWidget()
+        # zone de filtre
+        filter_layout = QHBoxLayout()
+        filter_layout.addWidget(QLabel("Filtre :"))
+        self.filter_edit = QLineEdit()
+        self.filter_edit.textChanged.connect(self._apply_filter)
+        filter_layout.addWidget(self.filter_edit)
+        main_layout.addLayout(filter_layout)
 
+        lists_layout = QHBoxLayout()
+        self.available_list = QListWidget()
+        self.available_list.setSelectionMode(QListWidget.MultiSelection)
         for curve in curves:
             item = QListWidgetItem(curve.name)
-            item.setFlags(item.flags() | Qt.ItemIsUserCheckable | Qt.ItemIsEditable)
-            item.setCheckState(Qt.Checked)
-            self.list_widget.addItem(item)
+            item.setData(Qt.UserRole, curve)
+            self.available_list.addItem(item)
 
-        layout.addWidget(self.list_widget)
+        self.selected_list = QListWidget()
+        self.selected_list.setSelectionMode(QListWidget.MultiSelection)
+
+        btn_layout = QVBoxLayout()
+        add_btn = QPushButton("→")
+        remove_btn = QPushButton("←")
+        add_btn.clicked.connect(self._add_selected)
+        remove_btn.clicked.connect(self._remove_selected)
+        btn_layout.addStretch()
+        btn_layout.addWidget(add_btn)
+        btn_layout.addWidget(remove_btn)
+        btn_layout.addStretch()
+
+        lists_layout.addWidget(self.available_list)
+        lists_layout.addLayout(btn_layout)
+        lists_layout.addWidget(self.selected_list)
+        main_layout.addLayout(lists_layout)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
-        layout.addWidget(buttons)
+        main_layout.addWidget(buttons)
+
+        # double click pour déplacer
+        self.available_list.itemDoubleClicked.connect(self._add_item)
+        self.selected_list.itemDoubleClicked.connect(self._remove_item)
 
     def get_selected_curves(self) -> List[CurveData]:
+        """Retourne les courbes sélectionnées dans la liste de droite."""
         selected = []
-        for i in range(self.list_widget.count()):
-            item = self.list_widget.item(i)
-            if item.checkState() == Qt.Checked:
-                curve = self.curves[i]
-                # 🔄 Met à jour le nom de la courbe avec le nom affiché (modifié ou non)
-                new_name = item.text().strip()
-                curve.name = new_name
-                selected.append(curve)
+        for i in range(self.selected_list.count()):
+            item = self.selected_list.item(i)
+            curve = item.data(Qt.UserRole)
+            new_name = item.text().strip()
+            curve.name = new_name
+            selected.append(curve)
         return selected
+
+    # --- actions internes ---
+
+    def _apply_filter(self):
+        pattern = self.filter_edit.text().strip()
+        for i in range(self.available_list.count()):
+            item = self.available_list.item(i)
+            visible = True
+            if pattern:
+                visible = fnmatch.fnmatch(item.text(), pattern)
+            item.setHidden(not visible)
+
+    def _add_item(self, item: QListWidgetItem):
+        self._move_items([item], self.available_list, self.selected_list)
+
+    def _remove_item(self, item: QListWidgetItem):
+        self._move_items([item], self.selected_list, self.available_list)
+        self._apply_filter()
+
+    def _add_selected(self):
+        items = self.available_list.selectedItems()
+        self._move_items(items, self.available_list, self.selected_list)
+
+    def _remove_selected(self):
+        items = self.selected_list.selectedItems()
+        self._move_items(items, self.selected_list, self.available_list)
+        self._apply_filter()
+
+    def _move_items(self, items, src: QListWidget, dst: QListWidget):
+        for item in list(items):
+            src.takeItem(src.row(item))
+            item.setFlags(item.flags() | Qt.ItemIsEditable)
+            dst.addItem(item)


### PR DESCRIPTION
## Summary
- update `CurveSelectionDialog` with filter box and dual lists
- add tests for filtering/selection behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c000d9328832d83dccfa2c3f60a73