### PR TITLE
Add CSV separator option

### DIFF
--- a/IO_dossier/curve_loader_factory.py
+++ b/IO_dossier/curve_loader_factory.py
@@ -9,13 +9,13 @@ import numpy as np
 from ui.dialogs.curve_selection_dialog import CurveSelectionDialog
 
 
-def load_curve_by_format(path: str, fmt: str) -> List[CurveData]:
+def load_curve_by_format(path: str, fmt: str, *, sep: str = ",") -> List[CurveData]:
     if fmt == "internal_json":
         return [load_internal_json(path)]
     elif fmt == "keysight_bin":
         return load_keysight_bin(path)
     elif fmt == "csv_standard":
-        return load_curves_from_file(path)
+        return load_curves_from_file(path, sep=sep)
     elif fmt == "keysight_json_v5":
         return load_keysight_json_v5(path)
     elif fmt == "tektro_json_v1_2":

--- a/IO_dossier/import_utils.py
+++ b/IO_dossier/import_utils.py
@@ -4,14 +4,21 @@ from typing import List
 from core.models import CurveData
 
 
-def import_curves_from_csv(path: str) -> List[CurveData]:
+def import_curves_from_csv(path: str, sep: str = ",") -> List[CurveData]:
     """Import curves from a CSV file.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+    sep:
+        Column separator used in the file (default is comma).
 
     The first column is used as the X axis and all subsequent columns are
     interpreted as Y values for individual curves. Each curve name is taken
     from the corresponding column header.
     """
-    df = pd.read_csv(path)
+    df = pd.read_csv(path, sep=sep)
 
     # Ensure numeric types for all columns, converting invalid entries to NaN
     for column in df.columns:
@@ -37,11 +44,19 @@ def import_curves_from_csv(path: str) -> List[CurveData]:
     return curves
 
 
-def load_curves_from_file(path: str) -> List[CurveData]:
-    """Charge des courbes à partir d'un fichier CSV, Excel ou JSON."""
+def load_curves_from_file(path: str, sep: str = ",") -> List[CurveData]:
+    """Charge des courbes à partir d'un fichier CSV, Excel ou JSON.
+
+    Parameters
+    ----------
+    path:
+        Path to the file to load.
+    sep:
+        Column separator when reading CSV files.
+    """
     ext = path.lower().split('.')[-1]
     if ext == "csv":
-        return import_curves_from_csv(path)
+        return import_curves_from_csv(path, sep=sep)
     elif ext in ["xls", "xlsx"]:
         df = pd.read_excel(path)
     elif ext == "json":

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -32,3 +32,17 @@ def test_import_curves_from_csv_with_non_numeric(tmp_path):
     assert np.isnan(curves[0].x[1])
     assert curves[0].y[1] == 3
 
+
+def test_import_curves_from_csv_custom_separator(tmp_path):
+    csv_content = "x;a;b\n0;1;2\n1;3;4\n"
+    path = tmp_path / "data.csv"
+    path.write_text(csv_content)
+
+    curves = import_curves_from_csv(str(path), sep=";")
+
+    assert len(curves) == 2
+    assert curves[0].name == "a"
+    assert np.array_equal(curves[0].x, np.array([0, 1]))
+    assert np.array_equal(curves[0].y, np.array([1, 3]))
+
+

--- a/ui/application_coordinator.py
+++ b/ui/application_coordinator.py
@@ -90,7 +90,7 @@ class ApplicationCoordinator:
 
         dialog = ImportCurveDialog()
         if dialog.exec_():
-            path, fmt = dialog.get_selected_path_and_format()
+            path, fmt, sep = dialog.get_selected_path_and_format()
             if not fmt:
                 return
 
@@ -105,7 +105,7 @@ class ApplicationCoordinator:
                         index += 1
                     curves = [generate_random_curve(index)]
                 else:
-                    curves = load_curve_by_format(path, fmt)
+                    curves = load_curve_by_format(path, fmt, sep=sep)
 
                 last_name = None
                 for curve in curves:

--- a/ui/dialogs/import_curve_dialog.py
+++ b/ui/dialogs/import_curve_dialog.py
@@ -1,5 +1,14 @@
 from PyQt5 import QtWidgets
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QComboBox, QPushButton, QFileDialog, QLineEdit
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QComboBox,
+    QPushButton,
+    QFileDialog,
+    QLineEdit,
+)
 
 class ImportCurveDialog(QDialog):
     def __init__(self, parent=None):
@@ -9,8 +18,10 @@ class ImportCurveDialog(QDialog):
 
         self.selected_path = None
         self.selected_format = None
+        self.selected_sep = ","
 
         self._init_ui()
+        self._on_format_changed()
 
     def _init_ui(self):
         layout = QVBoxLayout()
@@ -36,6 +47,14 @@ class ImportCurveDialog(QDialog):
         file_layout.addWidget(self.browse_btn)
         layout.addLayout(file_layout)
 
+        # Champ séparateur CSV
+        sep_layout = QHBoxLayout()
+        self.sep_label = QLabel("Séparateur CSV :")
+        self.sep_edit = QLineEdit(",")
+        sep_layout.addWidget(self.sep_label)
+        sep_layout.addWidget(self.sep_edit)
+        layout.addLayout(sep_layout)
+
         # Boutons bas
         btn_layout = QHBoxLayout()
         import_btn = QPushButton("Importer")
@@ -54,6 +73,9 @@ class ImportCurveDialog(QDialog):
         disabled = fmt == "random_curve"
         self.path_edit.setDisabled(disabled)
         self.browse_btn.setDisabled(disabled)
+        csv = fmt == "csv_standard"
+        self.sep_label.setVisible(csv)
+        self.sep_edit.setVisible(csv)
 
     def _on_browse(self):
         path, _ = QFileDialog.getOpenFileName(self, "Sélectionner un fichier", "", "Tous les fichiers (*)")
@@ -68,7 +90,8 @@ class ImportCurveDialog(QDialog):
             return
         self.selected_path = path if fmt != "random_curve" else None
         self.selected_format = fmt
+        self.selected_sep = self.sep_edit.text() or ","
         self.accept()
 
     def get_selected_path_and_format(self):
-        return self.selected_path, self.selected_format
+        return self.selected_path, self.selected_format, self.selected_sep

--- a/ui/ui_main_window.py
+++ b/ui/ui_main_window.py
@@ -189,7 +189,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         dlg = ImportCurveDialog(self)
         if dlg.exec_() == QtWidgets.QDialog.Accepted:
-            path, fmt = dlg.get_selected_path_and_format()
+            path, fmt, sep = dlg.get_selected_path_and_format()
             try:
                 if fmt == "random_curve":
                     existing_names = [c.name for c in graph.curves]
@@ -199,7 +199,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     curve = generate_random_curve(index)
                     curves = [curve]
                 else:
-                    curves = load_curve_by_format(path, fmt)
+                    curves = load_curve_by_format(path, fmt, sep=sep)
 
                 for curve in curves:
                     self.app.controller.service.add_curve(graph.name, curve)


### PR DESCRIPTION
## Summary
- allow customizing separator for CSV imports
- expose separator in import dialog UI
- pass separator through application coordinator and main window
- support optional separator in `load_curves_from_file`
- test custom separator handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0734487c832da7509f3ac56588eb