### PR TITLE
Support unique curve names on import

### DIFF
--- a/core/utils/naming.py
+++ b/core/utils/naming.py
@@ -26,3 +26,27 @@ def get_next_graph_name():
 
     logger.debug(f"✅ Nom disponible généré : {proposed_name}")
     return proposed_name
+
+
+def get_unique_curve_name(base_name: str, existing_names: set[str]) -> str:
+    """Return a unique curve name based on *base_name* not present in *existing_names*.
+
+    If *base_name* is already used, the function appends ``" (n)"`` where ``n``
+    is the smallest integer ensuring uniqueness.
+    """
+    logger.debug(
+        f"🔍 [get_unique_curve_name] base='{base_name}' existing={list(existing_names)}"
+    )
+    if base_name not in existing_names:
+        logger.debug(f"✅ Nom disponible généré : {base_name}")
+        return base_name
+
+    index = 1
+    proposed = f"{base_name} ({index})"
+    while proposed in existing_names:
+        logger.debug(f"⛔️ Nom déjà utilisé : {proposed}")
+        index += 1
+        proposed = f"{base_name} ({index})"
+
+    logger.debug(f"✅ Nom disponible généré : {proposed}")
+    return proposed

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -45,7 +45,8 @@ def test_add_graph_and_curve(service):
     assert state.current_graph.name == name
     svc.add_curve(name, curve=CurveData(name="tmp", x=[0], y=[0]))
     assert len(state.current_graph.curves) == 1
-    assert state.current_curve.name == "Courbe 1"
+    # the provided name should be kept since no conflict exists
+    assert state.current_curve.name == "tmp"
 
 
 def test_rename_graph_and_curve(service):
@@ -56,7 +57,7 @@ def test_rename_graph_and_curve(service):
     svc.rename_graph(name, "NewGraph")
     assert "NewGraph" in state.graphs
     svc.select_graph("NewGraph")
-    svc.rename_curve("Courbe 1", "Renamed")
+    svc.rename_curve("tmp", "Renamed")
     assert state.current_graph.curves[0].name == "Renamed"
 
 
@@ -69,7 +70,7 @@ def test_set_visibility(service):
     svc.set_graph_visible(graph, False)
     assert state.graphs[graph].visible is False
 
-    svc.set_curve_visible(graph, "Courbe 1", False)
+    svc.set_curve_visible(graph, "tmp", False)
     assert state.graphs[graph].curves[0].visible is False
 
 def test_graph_options(service):
@@ -130,8 +131,20 @@ def test_bring_curve_to_front_moves_curve(service):
     svc.add_curve(graph, curve=CurveData(name="a", x=[0], y=[0]))
     svc.add_curve(graph, curve=CurveData(name="b", x=[0], y=[0]))
 
-    svc.select_curve("Courbe 1")
+    svc.select_curve("a")
     svc.bring_curve_to_front()
 
     curves = [c.name for c in state.current_graph.curves]
-    assert curves[-1] == "Courbe 1"
+    assert curves[-1] == "a"
+
+
+def test_add_curve_duplicate_name_appends_index(service):
+    svc, state, _ = service
+    svc.add_graph()
+    graph = list(state.graphs.keys())[0]
+
+    svc.add_curve(graph, curve=CurveData(name="dup", x=[0], y=[0]))
+    svc.add_curve(graph, curve=CurveData(name="dup", x=[0], y=[0]))
+
+    assert state.graphs[graph].curves[0].name == "dup"
+    assert state.graphs[graph].curves[1].name == "dup (1)"


### PR DESCRIPTION
## Summary
- keep curve names on import and append `(n)` when duplicates are found
- expose `get_unique_curve_name` helper
- test duplicate naming behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0e2a1654832d81eef9d63c3d04e9