### PR TITLE
Fix CSV import for comma decimals and add Excel importer

### DIFF
--- a/IO_dossier/curve_loader_factory.py
+++ b/IO_dossier/curve_loader_factory.py
@@ -2,7 +2,11 @@ import json
 from typing import List
 from core.models import CurveData
 from .serializers import dict_to_curve
-from .import_utils import load_curves_from_file
+from .import_utils import (
+    load_curves_from_file,
+    import_curves_from_csv,
+    import_curves_from_excel,
+)
 import struct
 from collections import namedtuple
 import numpy as np
@@ -26,6 +30,10 @@ def load_curve_by_format(path: str, fmt: str, *, sep: str = ",") -> List[CurveDa
     elif fmt == "keysight_bin":
         curves = load_keysight_bin(path)
     elif fmt == "csv_standard":
+        curves = import_curves_from_csv(path, sep=sep)
+    elif fmt == "excel":
+        curves = import_curves_from_excel(path)
+    elif fmt == "csv_or_excel":  # backward compatibility
         curves = load_curves_from_file(path, sep=sep)
     elif fmt == "keysight_json_v5":
         curves = load_keysight_json_v5(path)

--- a/IO_dossier/import_utils.py
+++ b/IO_dossier/import_utils.py
@@ -22,7 +22,7 @@ def import_curves_from_csv(path: str, sep: str = ",") -> List[CurveData]:
     from the corresponding column header.
     """
     logger.debug(f"📂 [import_curves_from_csv] Lecture du fichier: {path} (sep='{sep}')")
-    df = pd.read_csv(path, sep=sep)
+    df = pd.read_csv(path, sep=sep, decimal=',')
     logger.debug(f"📝 [import_curves_from_csv] Colonnes détectées: {list(df.columns)}")
     logger.debug(f"🔢 [import_curves_from_csv] Nombre de lignes: {len(df)}")
 
@@ -55,6 +55,31 @@ def import_curves_from_csv(path: str, sep: str = ",") -> List[CurveData]:
     return curves
 
 
+def import_curves_from_excel(path: str) -> List[CurveData]:
+    """Import curves from an Excel file (.xls or .xlsx)."""
+    logger.debug(f"📂 [import_curves_from_excel] Lecture du fichier: {path}")
+    df = pd.read_excel(path)
+    logger.debug(f"📝 [import_curves_from_excel] Colonnes détectées: {list(df.columns)}")
+    logger.debug(f"🔢 [import_curves_from_excel] Nombre de lignes: {len(df)}")
+
+    if df.shape[1] < 2:
+        raise ValueError("Le fichier doit contenir au moins deux colonnes pour x et y.")
+
+    x_col = df.columns[0]
+    y_cols = df.columns[1:]
+
+    curves = []
+    for col in y_cols:
+        x_data = pd.to_numeric(df[x_col], errors="coerce").to_numpy()
+        y_data = pd.to_numeric(df[col], errors="coerce").to_numpy()
+        logger.debug(
+            f"📈 [import_curves_from_excel] Courbe '{col}' avec {len(x_data)} points"
+        )
+        curves.append(CurveData(name=col, x=x_data, y=y_data))
+
+    return curves
+
+
 def load_curves_from_file(path: str, sep: str = ",") -> List[CurveData]:
     """Charge des courbes à partir d'un fichier CSV, Excel ou JSON.
 
@@ -70,9 +95,11 @@ def load_curves_from_file(path: str, sep: str = ",") -> List[CurveData]:
     if ext == "csv":
         return import_curves_from_csv(path, sep=sep)
     elif ext in ["xls", "xlsx"]:
-        df = pd.read_excel(path)
+        return import_curves_from_excel(path)
     elif ext == "json":
         df = pd.read_json(path)
+        for column in df.columns:
+            df[column] = pd.to_numeric(df[column], errors="coerce")
     else:
         raise ValueError(f"Format de fichier non supporté: {ext}")
 

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -46,3 +46,15 @@ def test_import_curves_from_csv_custom_separator(tmp_path):
     assert np.array_equal(curves[0].y, np.array([1, 3]))
 
 
+def test_import_curves_from_csv_decimal_comma(tmp_path):
+    csv_content = "x;a;b\n0,5;1,2;2,2\n1,5;3,3;4,4\n"
+    path = tmp_path / "data.csv"
+    path.write_text(csv_content)
+
+    curves = import_curves_from_csv(str(path), sep=";")
+
+    assert len(curves) == 2
+    assert np.allclose(curves[0].x, np.array([0.5, 1.5]))
+    assert np.allclose(curves[0].y, np.array([1.2, 3.3]))
+
+

--- a/ui/dialogs/import_curve_dialog.py
+++ b/ui/dialogs/import_curve_dialog.py
@@ -34,6 +34,7 @@ class ImportCurveDialog(QDialog):
         self.format_combo.addItem("Oscilloscope Keysight V5 / JSON", "keysight_json_v5")
         self.format_combo.addItem("Oscilloscope TEKTRO V1.2 / JSON", "tektro_json_v1_2")
         self.format_combo.addItem("CSV Standard", "csv_standard")
+        self.format_combo.addItem("Fichier Excel", "excel")
         self.format_combo.addItem("➕ Générer une courbe aléatoire", "random_curve")
         self.format_combo.currentIndexChanged.connect(self._on_format_changed)
         layout.addWidget(self.format_combo)


### PR DESCRIPTION
## Summary
- handle comma decimals when reading CSV
- add separate Excel import function
- update loader factory and import dialog for Excel support
- test CSV import with comma decimals

## Testing
- `pytest tests/test_import_utils.py -q`
- `pytest tests/test_import_utils.py::test_import_curves_from_csv_decimal_comma -q`


------
https://chatgpt.com/codex/tasks/task_e_684c61488484832d8cf84c082ae922ca