### PR TITLE
Add flexible time column handling for imports

### DIFF
--- a/IO_dossier/curve_loader_factory.py
+++ b/IO_dossier/curve_loader_factory.py
@@ -6,6 +6,7 @@ from .import_utils import (
     load_curves_from_file,
     import_curves_from_csv,
     import_curves_from_excel,
+    TimeMode,
 )
 import struct
 from collections import namedtuple
@@ -23,18 +24,22 @@ def _select_curves(curves: List[CurveData]) -> List[CurveData]:
     return []
 
 
-def load_curve_by_format(path: str, fmt: str, *, sep: str = ",") -> List[CurveData]:
+def load_curve_by_format(
+    path: str, fmt: str, *, sep: str = ",", mode: TimeMode = TimeMode.NUMERIC
+) -> List[CurveData]:
     """Load curves according to the given format and ask the user which ones to keep."""
+    if isinstance(mode, str):
+        mode = TimeMode(mode)
     if fmt == "internal_json":
         curves = [load_internal_json(path)]
     elif fmt == "keysight_bin":
         curves = load_keysight_bin(path)
     elif fmt == "csv_standard":
-        curves = import_curves_from_csv(path, sep=sep)
+        curves = import_curves_from_csv(path, sep=sep, mode=mode)
     elif fmt == "excel":
-        curves = import_curves_from_excel(path)
+        curves = import_curves_from_excel(path, mode=mode)
     elif fmt == "csv_or_excel":  # backward compatibility
-        curves = load_curves_from_file(path, sep=sep)
+        curves = load_curves_from_file(path, sep=sep, mode=mode)
     elif fmt == "keysight_json_v5":
         curves = load_keysight_json_v5(path)
     elif fmt == "tektro_json_v1_2":

--- a/IO_dossier/import_utils.py
+++ b/IO_dossier/import_utils.py
@@ -1,13 +1,70 @@
 
 import pandas as pd
 from typing import List
+from enum import Enum
+
+
+class TimeMode(Enum):
+    """How the first column of imported data should be interpreted."""
+
+    INDEX = "index"  # No X column provided; use row indices.
+    NUMERIC = "numeric"  # First column already numeric X values.
+    IGNORE = "ignore"  # First column ignored, X uses row indices.
+    TIMESTAMP_RELATIVE = "timestamp_relative"  # Parse timestamps, first value at 0s.
+    TIMESTAMP_ABSOLUTE = "timestamp_absolute"  # Parse timestamps as seconds since epoch.
+
 from core.models import CurveData
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-def import_curves_from_csv(path: str, sep: str = ",") -> List[CurveData]:
+def _curves_from_dataframe(df: pd.DataFrame, mode: TimeMode) -> List[CurveData]:
+    """Convert a pandas DataFrame to CurveData objects according to time mode."""
+    curves = []
+
+    if mode == TimeMode.INDEX:
+        x = df.index.to_numpy()
+        y_cols = df.columns
+    elif mode == TimeMode.IGNORE:
+        if df.shape[1] < 2:
+            raise ValueError(
+                "Le fichier doit contenir au moins deux colonnes pour ignorer la première."
+            )
+        x = df.index.to_numpy()
+        y_cols = df.columns[1:]
+    else:
+        if df.shape[1] < 2:
+            raise ValueError(
+                "Le fichier doit contenir au moins deux colonnes pour x et y."
+            )
+        x_series = df.iloc[:, 0]
+
+        if mode == TimeMode.NUMERIC:
+            x = pd.to_numeric(x_series, errors="coerce").to_numpy()
+        else:
+            dt = pd.to_datetime(x_series, errors="coerce")
+            if mode == TimeMode.TIMESTAMP_RELATIVE:
+                start = dt.iloc[0]
+                x = (dt - start).dt.total_seconds().to_numpy()
+            else:  # TIMESTAMP_ABSOLUTE
+                x = (dt.astype("int64") / 1e9).to_numpy()
+
+        y_cols = df.columns[1:]
+
+    for col in y_cols:
+        y_data = pd.to_numeric(df[col], errors="coerce").to_numpy()
+        logger.debug(
+            f"📈 [_curves_from_dataframe] Courbe '{col}' avec {len(x)} points"
+        )
+        curves.append(CurveData(name=col, x=x, y=y_data))
+
+    return curves
+
+
+def import_curves_from_csv(
+    path: str, sep: str = ",", mode: TimeMode = TimeMode.NUMERIC
+) -> List[CurveData]:
     """Import curves from a CSV file.
 
     Parameters
@@ -26,61 +83,22 @@ def import_curves_from_csv(path: str, sep: str = ",") -> List[CurveData]:
     logger.debug(f"📝 [import_curves_from_csv] Colonnes détectées: {list(df.columns)}")
     logger.debug(f"🔢 [import_curves_from_csv] Nombre de lignes: {len(df)}")
 
-    # Ensure numeric types for all columns, converting invalid entries to NaN
-    for column in df.columns:
-        df[column] = pd.to_numeric(df[column], errors="coerce")
-
-    if df.shape[1] < 2:
-        raise ValueError(
-            "Le fichier doit contenir au moins deux colonnes pour x et y."
-        )
-
-    x_col = df.columns[0]
-    y_cols = df.columns[1:]
-
-    curves = []
-    for col in y_cols:
-        x_data = df[x_col].to_numpy()
-        y_data = df[col].to_numpy()
-        logger.debug(
-            f"📈 [import_curves_from_csv] Courbe '{col}' avec {len(x_data)} points"
-        )
-        curves.append(
-            CurveData(
-                name=col,
-                x=x_data,
-                y=y_data,
-            )
-        )
-    return curves
+    return _curves_from_dataframe(df, mode)
 
 
-def import_curves_from_excel(path: str) -> List[CurveData]:
+def import_curves_from_excel(path: str, mode: TimeMode = TimeMode.NUMERIC) -> List[CurveData]:
     """Import curves from an Excel file (.xls or .xlsx)."""
     logger.debug(f"📂 [import_curves_from_excel] Lecture du fichier: {path}")
     df = pd.read_excel(path)
     logger.debug(f"📝 [import_curves_from_excel] Colonnes détectées: {list(df.columns)}")
     logger.debug(f"🔢 [import_curves_from_excel] Nombre de lignes: {len(df)}")
 
-    if df.shape[1] < 2:
-        raise ValueError("Le fichier doit contenir au moins deux colonnes pour x et y.")
-
-    x_col = df.columns[0]
-    y_cols = df.columns[1:]
-
-    curves = []
-    for col in y_cols:
-        x_data = pd.to_numeric(df[x_col], errors="coerce").to_numpy()
-        y_data = pd.to_numeric(df[col], errors="coerce").to_numpy()
-        logger.debug(
-            f"📈 [import_curves_from_excel] Courbe '{col}' avec {len(x_data)} points"
-        )
-        curves.append(CurveData(name=col, x=x_data, y=y_data))
-
-    return curves
+    return _curves_from_dataframe(df, mode)
 
 
-def load_curves_from_file(path: str, sep: str = ",") -> List[CurveData]:
+def load_curves_from_file(
+    path: str, sep: str = ",", mode: TimeMode = TimeMode.NUMERIC
+) -> List[CurveData]:
     """Charge des courbes à partir d'un fichier CSV, Excel ou JSON.
 
     Parameters
@@ -93,9 +111,9 @@ def load_curves_from_file(path: str, sep: str = ",") -> List[CurveData]:
     logger.debug(f"📂 [load_curves_from_file] Lecture du fichier: {path}")
     ext = path.lower().split('.')[-1]
     if ext == "csv":
-        return import_curves_from_csv(path, sep=sep)
+        return import_curves_from_csv(path, sep=sep, mode=mode)
     elif ext in ["xls", "xlsx"]:
-        return import_curves_from_excel(path)
+        return import_curves_from_excel(path, mode=mode)
     elif ext == "json":
         df = pd.read_json(path)
         for column in df.columns:
@@ -103,25 +121,5 @@ def load_curves_from_file(path: str, sep: str = ",") -> List[CurveData]:
     else:
         raise ValueError(f"Format de fichier non supporté: {ext}")
 
-    if df.shape[1] < 2:
-        raise ValueError("Le fichier doit contenir au moins deux colonnes pour x et y.")
-
-    x_col = df.columns[0]
-    y_cols = df.columns[1:]
-
-    curves = []
-    for col in y_cols:
-        x_data = df[x_col].to_numpy()
-        y_data = df[col].to_numpy()
-        logger.debug(
-            f"📈 [load_curves_from_file] Courbe '{col}' avec {len(x_data)} points"
-        )
-        curves.append(
-            CurveData(
-                name=col,
-                x=x_data,
-                y=y_data,
-            )
-        )
-    return curves
+    return _curves_from_dataframe(df, mode)
 

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from IO_dossier.import_utils import import_curves_from_csv
+from IO_dossier.import_utils import import_curves_from_csv, TimeMode
 
 
 def test_import_curves_from_csv(tmp_path):
@@ -56,5 +56,36 @@ def test_import_curves_from_csv_decimal_comma(tmp_path):
     assert len(curves) == 2
     assert np.allclose(curves[0].x, np.array([0.5, 1.5]))
     assert np.allclose(curves[0].y, np.array([1.2, 3.3]))
+
+
+def test_import_curves_with_index_mode(tmp_path):
+    csv_content = "a,b\n1,2\n3,4\n"
+    path = tmp_path / "data.csv"
+    path.write_text(csv_content)
+
+    curves = import_curves_from_csv(str(path), mode=TimeMode.INDEX)
+
+    assert len(curves) == 2
+    assert np.array_equal(curves[0].x, np.array([0, 1]))
+
+
+def test_import_curves_timestamp_relative(tmp_path):
+    csv_content = "t,a\n2025-06-07 T08:38:59,1\n2025-06-07 T08:39:00,2\n"
+    path = tmp_path / "data.csv"
+    path.write_text(csv_content)
+
+    curves = import_curves_from_csv(str(path), mode=TimeMode.TIMESTAMP_RELATIVE)
+
+    assert np.array_equal(curves[0].x, np.array([0.0, 1.0]))
+
+
+def test_import_curves_timestamp_absolute(tmp_path):
+    csv_content = "t,a\n2025-06-07 T08:38:59,1\n2025-06-07 T08:39:00,2\n"
+    path = tmp_path / "data.csv"
+    path.write_text(csv_content)
+
+    curves = import_curves_from_csv(str(path), mode=TimeMode.TIMESTAMP_ABSOLUTE)
+
+    assert curves[0].x[1] - curves[0].x[0] == 1.0
 
 

--- a/ui/application_coordinator.py
+++ b/ui/application_coordinator.py
@@ -90,7 +90,7 @@ class ApplicationCoordinator:
 
         dialog = ImportCurveDialog()
         if dialog.exec_():
-            path, fmt, sep = dialog.get_selected_path_and_format()
+            path, fmt, sep, mode = dialog.get_selected_path_and_format()
             if not fmt:
                 return
 
@@ -105,7 +105,7 @@ class ApplicationCoordinator:
                         index += 1
                     curves = [generate_random_curve(index)]
                 else:
-                    curves = load_curve_by_format(path, fmt, sep=sep)
+                    curves = load_curve_by_format(path, fmt, sep=sep, mode=mode)
 
                 last_name = None
                 for curve in curves:

--- a/ui/dialogs/import_curve_dialog.py
+++ b/ui/dialogs/import_curve_dialog.py
@@ -19,6 +19,7 @@ class ImportCurveDialog(QDialog):
         self.selected_path = None
         self.selected_format = None
         self.selected_sep = ","
+        self.selected_mode = "numeric"
 
         self._init_ui()
         self._on_format_changed()
@@ -56,6 +57,19 @@ class ImportCurveDialog(QDialog):
         sep_layout.addWidget(self.sep_edit)
         layout.addLayout(sep_layout)
 
+        # Time handling options
+        mode_layout = QHBoxLayout()
+        self.mode_label = QLabel("Gestion du temps :")
+        self.mode_combo = QComboBox()
+        self.mode_combo.addItem("Pas de colonne (index)", "index")
+        self.mode_combo.addItem("Première colonne numérique", "numeric")
+        self.mode_combo.addItem("Ignorer la première colonne", "ignore")
+        self.mode_combo.addItem("Horodatage relatif", "timestamp_relative")
+        self.mode_combo.addItem("Horodatage absolu", "timestamp_absolute")
+        mode_layout.addWidget(self.mode_label)
+        mode_layout.addWidget(self.mode_combo)
+        layout.addLayout(mode_layout)
+
         # Boutons bas
         btn_layout = QHBoxLayout()
         import_btn = QPushButton("Importer")
@@ -77,6 +91,9 @@ class ImportCurveDialog(QDialog):
         csv = fmt == "csv_standard"
         self.sep_label.setVisible(csv)
         self.sep_edit.setVisible(csv)
+        time_visible = fmt in ("csv_standard", "excel", "csv_or_excel")
+        self.mode_label.setVisible(time_visible)
+        self.mode_combo.setVisible(time_visible)
 
     def _on_browse(self):
         path, _ = QFileDialog.getOpenFileName(self, "Sélectionner un fichier", "", "Tous les fichiers (*)")
@@ -92,7 +109,8 @@ class ImportCurveDialog(QDialog):
         self.selected_path = path if fmt != "random_curve" else None
         self.selected_format = fmt
         self.selected_sep = self.sep_edit.text() or ","
+        self.selected_mode = self.mode_combo.currentData()
         self.accept()
 
     def get_selected_path_and_format(self):
-        return self.selected_path, self.selected_format, self.selected_sep
+        return self.selected_path, self.selected_format, self.selected_sep, self.selected_mode

--- a/ui/ui_main_window.py
+++ b/ui/ui_main_window.py
@@ -189,7 +189,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         dlg = ImportCurveDialog(self)
         if dlg.exec_() == QtWidgets.QDialog.Accepted:
-            path, fmt, sep = dlg.get_selected_path_and_format()
+            path, fmt, sep, mode = dlg.get_selected_path_and_format()
             try:
                 if fmt == "random_curve":
                     existing_names = [c.name for c in graph.curves]
@@ -199,7 +199,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     curve = generate_random_curve(index)
                     curves = [curve]
                 else:
-                    curves = load_curve_by_format(path, fmt, sep=sep)
+                    curves = load_curve_by_format(path, fmt, sep=sep, mode=mode)
 
                 for curve in curves:
                     self.app.controller.service.add_curve(graph.name, curve)


### PR DESCRIPTION
## Summary
- support multiple time modes when importing curves
- extend ImportCurveDialog with time management options
- wire selected time mode through the UI and loader factory
- update tests for new import behaviors

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c679a15a4832d953057164407d2d7