### PR TITLE
Improve bit import clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-__pycache__/app_state.cpython-312.pyc
-__pycache__/app_state.cpython-312.pyc
-__pycache__/CentralPlotArea.cpython-312.pyc
-__pycache__/controllers.cpython-312.pyc
-__pycache__/curve_selection_dialog.cpython-312.pyc
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -17,4 +17,6 @@ python main.py
 ```
 
 When importing curves from files (CSV, JSON, BIN, etc.) a selection dialog
-lets you choose which curves are actually added to the project.
+lets you choose which curves are actually added to the project. If you opt to
+extract a specific bit from the selected curves, the resulting curve name is
+automatically suffixed with the bit number, e.g. `mycurve-[0]`.

--- a/tests/test_curve_selection_dialog.py
+++ b/tests/test_curve_selection_dialog.py
@@ -39,3 +39,4 @@ def test_bit_extraction():
     selected = dlg.get_selected_curves()
     assert len(selected) == 1
     assert np.array_equal(selected[0].y, np.array([0, 1, 0, 1]))
+    assert selected[0].name == "c1-[0]"

--- a/ui/dialogs/curve_selection_dialog.py
+++ b/ui/dialogs/curve_selection_dialog.py
@@ -42,7 +42,8 @@ class CurveSelectionDialog(QDialog):
 
         # Bit extraction option
         bit_layout = QHBoxLayout()
-        self.bit_checkbox = QCheckBox("Extraire le bit :")
+        # Clarify that the bit extraction applies to all selected curves
+        self.bit_checkbox = QCheckBox("Extraire le bit (toutes les courbes) :")
         self.bit_spin = QSpinBox()
         self.bit_spin.setRange(0, 31)
         self.bit_spin.setValue(0)
@@ -101,6 +102,8 @@ class CurveSelectionDialog(QDialog):
                 bit = self.bit_spin.value()
                 y_int = np.array(curve.y, dtype=int)
                 curve.y = ((y_int >> bit) & 1).astype(curve.y.dtype)
+                # Append the bit number to the curve name for clarity
+                curve.name = f"{curve.name}-[{bit}]"
             selected.append(curve)
         return selected
 


### PR DESCRIPTION
## Summary
- clarify that bit extraction applies to all curves in the dialog
- automatically append selected bit number to curve names
- update documentation and tests accordingly
- ignore pycache files

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8a1e2704832d801270c519ce5504