### PR TITLE
Supprimer l'import de bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,4 @@ python main.py
 ```
 
 When importing curves from files (CSV, JSON, BIN, etc.) a selection dialog
-lets you choose which curves are actually added to the project. If you opt to
-extract a specific bit from the selected curves, the resulting curve name is
-automatically suffixed with the bit number, e.g. `mycurve-[0]`.
+lets you choose which curves are actually added to the project.

--- a/tests/test_curve_selection_dialog.py
+++ b/tests/test_curve_selection_dialog.py
@@ -26,17 +26,3 @@ def test_filter_and_selection():
     selected = dlg.get_selected_curves()
     assert len(selected) == 1
     assert selected[0].name == "temp1"
-
-
-def test_bit_extraction():
-    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
-    curves = [CurveData(name="c1", x=[0, 1, 2, 3], y=[2, 5, 6, 9])]
-    dlg = CurveSelectionDialog(curves)
-    dlg.available_list.setCurrentRow(0)
-    dlg._add_selected()
-    dlg.bit_checkbox.setChecked(True)
-    dlg.bit_spin.setValue(0)
-    selected = dlg.get_selected_curves()
-    assert len(selected) == 1
-    assert np.array_equal(selected[0].y, np.array([0, 1, 0, 1]))
-    assert selected[0].name == "c1-[0]"

--- a/ui/dialogs/curve_selection_dialog.py
+++ b/ui/dialogs/curve_selection_dialog.py
@@ -8,15 +8,12 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QPushButton,
     QLineEdit,
-    QSpinBox,
-    QCheckBox,
 )
 from PyQt5.QtCore import Qt
 import fnmatch
 
 from typing import List
 from core.models import CurveData
-import numpy as np
 
 class CurveSelectionDialog(QDialog):
     """
@@ -39,21 +36,6 @@ class CurveSelectionDialog(QDialog):
         self.filter_edit.textChanged.connect(self._apply_filter)
         filter_layout.addWidget(self.filter_edit)
         main_layout.addLayout(filter_layout)
-
-        # Bit extraction option
-        bit_layout = QHBoxLayout()
-        # Clarify that the bit extraction applies to all selected curves
-        self.bit_checkbox = QCheckBox("Extraire le bit (toutes les courbes) :")
-        self.bit_spin = QSpinBox()
-        self.bit_spin.setRange(0, 31)
-        self.bit_spin.setValue(0)
-        self.bit_spin.setEnabled(False)
-        self.bit_checkbox.stateChanged.connect(
-            lambda state: self.bit_spin.setEnabled(state == Qt.Checked)
-        )
-        bit_layout.addWidget(self.bit_checkbox)
-        bit_layout.addWidget(self.bit_spin)
-        main_layout.addLayout(bit_layout)
 
         lists_layout = QHBoxLayout()
         self.available_list = QListWidget()
@@ -98,12 +80,6 @@ class CurveSelectionDialog(QDialog):
             curve = item.data(Qt.UserRole)
             new_name = item.text().strip()
             curve.name = new_name
-            if self.bit_checkbox.isChecked():
-                bit = self.bit_spin.value()
-                y_int = np.array(curve.y, dtype=int)
-                curve.y = ((y_int >> bit) & 1).astype(curve.y.dtype)
-                # Append the bit number to the curve name for clarity
-                curve.name = f"{curve.name}-[{bit}]"
             selected.append(curve)
         return selected
 


### PR DESCRIPTION
## Summary
- retire la logique d'extraction de bits dans `CurveSelectionDialog`
- supprime le test associé
- met à jour la documentation sur l'import de courbes

## Testing
- `pre-commit run --files README.md tests/test_curve_selection_dialog.py ui/dialogs/curve_selection_dialog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c911a1570832db1dc63ae15145ee9