### PR TITLE
Enhance curve panel and randomize colors

### DIFF
--- a/IO_dossier/import_utils.py
+++ b/IO_dossier/import_utils.py
@@ -14,6 +14,7 @@ class TimeMode(Enum):
     TIMESTAMP_ABSOLUTE = "timestamp_absolute"  # Parse timestamps as seconds since epoch.
 
 from core.models import CurveData
+from core.utils import generate_random_color
 import logging
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,9 @@ def _curves_from_dataframe(df: pd.DataFrame, mode: TimeMode) -> List[CurveData]:
         logger.debug(
             f"📈 [_curves_from_dataframe] Courbe '{col}' avec {len(x)} points"
         )
-        curves.append(CurveData(name=col, x=x, y=y_data))
+        curves.append(
+            CurveData(name=col, x=x, y=y_data, color=generate_random_color())
+        )
 
     return curves
 

--- a/IO_dossier/serializers.py
+++ b/IO_dossier/serializers.py
@@ -2,6 +2,7 @@
 import numpy as np
 from typing import List, Dict
 from core.models import CurveData, GraphData
+from core.utils import generate_random_color
 
 
 def curve_to_dict(curve: CurveData) -> dict:
@@ -29,11 +30,14 @@ def curve_to_dict(curve: CurveData) -> dict:
 
 
 def dict_to_curve(data: dict) -> CurveData:
+    color = data.get("color")
+    if not color or color.lower() in {"#000000", "black", "#ffffff", "white", "b", "w"}:
+        color = generate_random_color()
     return CurveData(
         name=data["name"],
         x=data["x"],
         y=data["y"],
-        color=data.get("color", "b"),
+        color=color,
         width=data.get("width", 2),
         style=data.get("style"),
         downsampling_mode=data.get("downsampling_mode", "auto"),

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -3,6 +3,7 @@
 from core.app_state import AppState
 from core.models import GraphData, CurveData
 from core.utils.naming import get_next_graph_name, get_unique_curve_name
+from core.utils import generate_random_color
 from typing import Optional
 import logging
 
@@ -115,7 +116,7 @@ class GraphService:
             logger.debug(
                 f"🔧 [GraphService.add_curve] Génération d'une courbe vide nommée '{curve_name}'"
             )
-            curve = CurveData(name=curve_name)
+            curve = CurveData(name=curve_name, color=generate_random_color())
         else:
             # Keep the provided curve name when importing. If it already exists
             # in the target graph, append " (x)" where x is the smallest index
@@ -126,6 +127,8 @@ class GraphService:
                 f"📥 [GraphService.add_curve] Courbe fournie nommée '{curve.name}', renommée '{curve_name}'"
             )
             curve.name = curve_name
+            if curve.color.lower() in {"#000000", "black", "#ffffff", "white", "b", "w"}:
+                curve.color = generate_random_color()
     
         graph.curves.append(curve)
         self.state.current_graph = graph

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,0 +1,8 @@
+from .naming import get_next_graph_name, get_unique_curve_name
+from .color_utils import generate_random_color
+
+__all__ = [
+    'get_next_graph_name',
+    'get_unique_curve_name',
+    'generate_random_color',
+]

--- a/core/utils/color_utils.py
+++ b/core/utils/color_utils.py
@@ -1,0 +1,11 @@
+import random
+
+def generate_random_color() -> str:
+    """Return a random hex color excluding near-black and near-white shades."""
+    while True:
+        r = random.randint(0, 255)
+        g = random.randint(0, 255)
+        b = random.randint(0, 255)
+        if (r <= 30 and g <= 30 and b <= 30) or (r >= 225 and g >= 225 and b >= 225):
+            continue
+        return f"#{r:02X}{g:02X}{b:02X}"

--- a/curve_generators.py
+++ b/curve_generators.py
@@ -2,13 +2,13 @@
 import numpy as np
 from core.models import CurveData
 from PyQt5.QtCore import Qt
-import random
+from core.utils import generate_random_color
 
 def generate_random_curve(index=1) -> CurveData:
     x = np.linspace(0, 2 * np.pi, 1000)
     y = np.sin(np.random.uniform(1, 5) * x)
     name = f"Courbe {index}"
-    color = random.choice(['r', 'g', 'b', 'm', 'c', 'y'])
+    color = generate_random_color()
     return CurveData(
         name=name,
         x=x,


### PR DESCRIPTION
## Summary
- add `generate_random_color` utility
- randomize curve colors when generating, importing CSV data, or loading JSON
- ensure default-generated curves also get random colors
- keep tree expansion state recursively in GraphCurvePanel
- add numeric fields and apply buttons for gain and offset in PropertiesPanel

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684caec0c7e0832dbbcd79abc7395d46