### PR TITLE
Handle negative numbers in bit-curve generation

### DIFF
--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -231,10 +231,13 @@ class GraphService:
         values = curve.y.astype(np.int64)
         min_bits = max(int(values.max()).bit_length(), 1)
 
+        if values.min() < 0:
+            raise ValueError("Les valeurs négatives ne sont pas prises en charge")
+
         if bit_count is None:
             bit_count = min_bits
         else:
-            if values.min() < 0 or values.max() >= 2 ** bit_count:
+            if values.max() >= 2 ** bit_count:
                 raise ValueError("La plage de valeurs dépasse le nombre de bits spécifié")
 
         bits = ((values[:, None] >> np.arange(bit_count)) & 1).astype(float)

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -175,3 +175,14 @@ def test_create_bit_curves_invalid_data_raises(service):
 
     with pytest.raises(ValueError):
         svc.create_bit_curves("bad")
+
+
+def test_create_bit_curves_negative_values_raises(service):
+    svc, state, _ = service
+    svc.add_graph()
+    graph = list(state.graphs.keys())[0]
+    curve = CurveData(name="neg", x=[0, 1], y=[-1, 0])
+    svc.add_curve(graph, curve=curve)
+
+    with pytest.raises(ValueError):
+        svc.create_bit_curves("neg")


### PR DESCRIPTION
## Summary
- detect negative values before creating bit curves
- test that negative values raise an error

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb3d7da1c832d91ecc4f956cf1cb9