### PR TITLE
Allow dtype selection within curve import dialog

### DIFF
--- a/IO_dossier/curve_loader_factory.py
+++ b/IO_dossier/curve_loader_factory.py
@@ -12,7 +12,6 @@ import struct
 from collections import namedtuple
 import numpy as np
 from ui.dialogs.curve_selection_dialog import CurveSelectionDialog
-from ui.dialogs.data_type_dialog import DataTypeDialog
 
 
 def _select_curves(curves: List[CurveData]) -> List[CurveData]:
@@ -21,11 +20,7 @@ def _select_curves(curves: List[CurveData]) -> List[CurveData]:
         return []
     dlg = CurveSelectionDialog(curves)
     if dlg.exec_() == dlg.Accepted:
-        selected = dlg.get_selected_curves()
-        type_dlg = DataTypeDialog(selected)
-        if type_dlg.exec_() == type_dlg.Accepted:
-            return selected
-        return []
+        return dlg.get_selected_curves()
     return []
 
 

--- a/tests/test_curve_selection_dialog.py
+++ b/tests/test_curve_selection_dialog.py
@@ -5,7 +5,7 @@ from PyQt5 import QtWidgets
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from core.models import CurveData
+from core.models import CurveData, DataType
 from ui.dialogs.curve_selection_dialog import CurveSelectionDialog
 import numpy as np
 
@@ -26,3 +26,4 @@ def test_filter_and_selection():
     selected = dlg.get_selected_curves()
     assert len(selected) == 1
     assert selected[0].name == "temp1"
+    assert selected[0].dtype == DataType.FLOAT64

--- a/ui/dialogs/__init__.py
+++ b/ui/dialogs/__init__.py
@@ -1,9 +1,7 @@
 from .curve_selection_dialog import CurveSelectionDialog
 from .import_curve_dialog import ImportCurveDialog
-from .data_type_dialog import DataTypeDialog
 
 __all__ = [
     "CurveSelectionDialog",
     "ImportCurveDialog",
-    "DataTypeDialog",
 ]


### PR DESCRIPTION
## Summary
- update curve selection dialog with drop-downs to set data type
- drop the separate data type dialog
- adjust loader and tests accordingly

## Testing
- `pre-commit run --files IO_dossier/curve_loader_factory.py tests/test_curve_selection_dialog.py ui/dialogs/__init__.py ui/dialogs/curve_selection_dialog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de0b17428832d8b9a88eb624d9624