### PR TITLE
Add warning on incompatible type choice

### DIFF
--- a/tests/test_data_type_dialog.py
+++ b/tests/test_data_type_dialog.py
@@ -1,0 +1,20 @@
+import os
+import sys
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PyQt5 import QtWidgets
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.models import CurveData, DataType
+from ui.dialogs.data_type_dialog import DataTypeDialog
+
+
+def test_warning_label_updates():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    curve = CurveData(name="c", x=[0, 1], y=[0, 2.5])
+    dlg = DataTypeDialog([curve])
+    label = dlg._warn_labels[id(curve)]
+    assert label.text() == ""
+    combo = dlg._combos[id(curve)]
+    combo.setCurrentIndex(list(DataType).index(DataType.UINT8))
+    assert label.text() == "1/2 invalid"


### PR DESCRIPTION
## Summary
- improve DataTypeDialog to warn when choosing an incompatible dtype
- show per-curve indicator of incompatible values
- keep invalid values as NaN when accepting conversion
- test warning indicator for DataTypeDialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df88d49e4832d8306ecbe763c3b22