### PR TITLE
Handle NaN values when creating bit curves

### DIFF
--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -2,6 +2,7 @@ import os
 import sys
 import types
 import importlib
+import numpy as np
 import pytest
 from core.models import CurveData
 
@@ -186,3 +187,17 @@ def test_create_bit_curves_negative_values_raises(service):
 
     with pytest.raises(ValueError):
         svc.create_bit_curves("neg")
+
+
+def test_create_bit_curves_with_nan_values(service):
+    svc, state, _ = service
+    svc.add_graph()
+    graph = list(state.graphs.keys())[0]
+    curve = CurveData(name="nan", x=[0, 1, 2], y=[0, float('nan'), 3])
+    svc.add_curve(graph, curve=curve)
+
+    created = svc.create_bit_curves("nan")
+
+    assert created == ["nan[0]", "nan[1]"]
+    assert np.isnan(state.current_graph.curves[1].y[1])
+    assert np.isnan(state.current_graph.curves[2].y[1])

--- a/ui/GraphCurvePanel.py
+++ b/ui/GraphCurvePanel.py
@@ -282,12 +282,21 @@ class GraphCurvePanel(QtWidgets.QWidget):
             return
 
         import numpy as np
-        if not np.allclose(curve.y, np.round(curve.y)):
+
+        values = curve.y
+        mask = np.isnan(values)
+        finite_values = values[~mask]
+
+        if not np.allclose(finite_values, np.round(finite_values)):
             QtWidgets.QMessageBox.warning(self, "Erreur", "Les données ne sont pas entières")
             return
 
-        values = curve.y.astype(np.int64)
-        min_bits = max(int(values.max()).bit_length(), 1)
+        if finite_values.size:
+            max_val = int(finite_values.max())
+        else:
+            max_val = 0
+
+        min_bits = max(max_val.bit_length(), 1)
         bit_count, ok = QtWidgets.QInputDialog.getInt(
             self,
             "Décomposer la courbe",


### PR DESCRIPTION
## Summary
- allow GraphService.create_bit_curves to accept NaN values
- test NaN handling in bit curve creation
- allow GraphCurvePanel to expand curves with NaN samples

## Testing
- `pre-commit run --files ui/GraphCurvePanel.py core/graph_service.py tests/test_graph_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea5abe2b4832d8a55878b8a7d8af9