### PR TITLE
Add mode tab with automation presets

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -265,6 +265,12 @@ class GraphController:
         self.service.set_show_label(visible)
         self.ui.refresh_curve_ui()
 
+    def apply_mode(self, mode: str):
+        logger.debug(f"🎛 [GraphController.apply_mode] mode={mode}")
+        self.service.apply_mode(mode)
+        self.ui.refresh_graph_tab()
+        self.ui.refresh_curve_ui()
+
     def reset_zoom(self):
         logger.debug("🔍 [GraphController.reset_zoom] Réinitialisation du zoom")
         self.ui.reset_zoom()

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -425,3 +425,30 @@ class GraphService:
         if zone in graph.satellite_content:
             graph.satellite_content[zone] = content
             graph.satellite_visibility[zone] = bool(content)
+
+    def apply_mode(self, mode: str):
+        """Apply a predefined configuration to the current graph and curve."""
+        logger.debug(f"🎛 [GraphService.apply_mode] mode={mode}")
+        graph = self.state.current_graph
+        curve = self.state.current_curve
+        if not graph or not curve:
+            return
+
+        if mode == "standard":
+            graph.dark_mode = False
+            graph.grid_visible = True
+            curve.display_mode = "line"
+            curve.width = 2
+            curve.label_mode = "none"
+        elif mode == "analysis":
+            graph.dark_mode = False
+            graph.grid_visible = True
+            graph.log_x = False
+            graph.log_y = False
+            curve.display_mode = "line"
+            curve.label_mode = "legend"
+        elif mode == "dark":
+            graph.dark_mode = True
+            graph.grid_visible = True
+            curve.display_mode = "line"
+        logger.debug("🎛 [GraphService.apply_mode] configuration appliquée")

--- a/ui/PropertiesPanel.py
+++ b/ui/PropertiesPanel.py
@@ -145,13 +145,21 @@ class PropertiesPanel(QtWidgets.QTabWidget):
             )
         )
 
+        self.mode_combo.currentIndexChanged.connect(
+            lambda i: self._call_controller(
+                self.controller.apply_mode, self.mode_combo.itemData(i)
+            )
+        )
+
     def setup_ui(self):
         logger.debug("[PropertiesPanel.py > setup_ui()] ▶️ Entrée dans setup_ui()")
 
         self.setup_graph_tab()
         self.setup_curve_tab()
+        self.setup_mode_tab()
         self.setTabEnabled(0, False)
         self.setTabEnabled(1, False)
+        self.setTabEnabled(2, False)
 
     def setup_graph_tab(self):
         logger.debug("[PropertiesPanel.py > setup_graph_tab()] ▶️ Entrée dans setup_graph_tab()")
@@ -398,8 +406,25 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         layout.addWidget(self.label_mode_combo)
 
         layout.addStretch()
-        
+
         self.addTab(tab_curve, "Propriétés de la courbe")
+
+    def setup_mode_tab(self):
+        logger.debug("[PropertiesPanel.py > setup_mode_tab()] ▶️ Entrée dans setup_mode_tab()")
+
+        tab_mode = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(tab_mode)
+
+        self.mode_combo = QtWidgets.QComboBox()
+        self.mode_combo.addItem("Standard", "standard")
+        self.mode_combo.addItem("Analyse", "analysis")
+        self.mode_combo.addItem("Sombre", "dark")
+
+        layout.addWidget(QtWidgets.QLabel("Mode prédéfini :"))
+        layout.addWidget(self.mode_combo)
+        layout.addStretch()
+
+        self.addTab(tab_mode, "Mode")
 
     def _call_controller(self, func, *args):
         if not self.controller:

--- a/ui/application_coordinator.py
+++ b/ui/application_coordinator.py
@@ -142,12 +142,14 @@ class ApplicationCoordinator:
 
     def _on_curve_updated(self):
         self.main_window.show_curve_tab()
+        self.main_window.show_mode_tab()
 
     def _on_graph_selected(self, graph_name):
         self.main_window.show_graph_tab()
 
     def _on_curve_selected(self, graph_name, curve_name):
         self.main_window.show_curve_tab(graph_name, curve_name)
+        self.main_window.show_mode_tab()
 
     def _handle_rename_requested(self, kind, old_name, new_name):
         if kind == "graph":

--- a/ui/ui_main_window.py
+++ b/ui/ui_main_window.py
@@ -276,6 +276,11 @@ class MainWindow(QtWidgets.QMainWindow):
         logger.debug(f"[MainWindow] Activation de l'onglet Courbe : {graph_name} > {curve_name}")
         self.right_panel.setTabEnabled(1, True)
         self.right_panel.setCurrentIndex(1)
+
+    def show_mode_tab(self):
+        logger.debug("[MainWindow] Activation de l'onglet Mode")
+        self.right_panel.setTabEnabled(2, True)
+        self.right_panel.setCurrentIndex(2)
     
 
     def _show_about(self):


### PR DESCRIPTION
## Summary
- support applying preset modes on controller and service
- add a Mode tab in properties panel
- enable mode tab from the application coordinator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684edd5ca00c832d98ac373267b92932