### PR TITLE
Add grouped bit curves

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -112,6 +112,18 @@ class GraphController:
         self.ui.refresh_plot()
         return names
 
+    def create_bit_group_curve(
+        self, curve_name: str, bit_indices: list[int], group_name: Optional[str] = None
+    ):
+        logger.debug(
+            f"🔬 [GraphController.create_bit_group_curve] Groupe {bit_indices} pour {curve_name}"
+        )
+        name = self.service.create_bit_group_curve(curve_name, bit_indices, group_name)
+        signal_bus.curve_list_updated.emit()
+        signal_bus.curve_updated.emit()
+        self.ui.refresh_plot()
+        return name
+
     def bring_curve_to_front(self):
         logger.debug("🔝 [GraphController.bring_curve_to_front] Priorisation de la courbe")
         self.service.bring_curve_to_front()

--- a/tests/test_graph_controller.py
+++ b/tests/test_graph_controller.py
@@ -215,3 +215,20 @@ def test_controller_create_bit_curves(controller):
     assert created == [f"{curve.name}[0]", f"{curve.name}[1]"]
     assert len(state.current_graph.curves) == 3
     assert len(bus.curve_updated.emitted) == 1
+
+
+def test_controller_create_bit_group_curve(controller):
+    c, state, bus = controller
+    c.add_graph()
+    graph = list(state.graphs.keys())[0]
+    c.add_curve(graph)
+    curve = state.current_curve
+    curve.y = np.array([0, 1, 2, 3])
+    curve.x = np.array([0, 1, 2, 3])
+
+    bus.curve_updated.emitted.clear()
+    created = c.create_bit_group_curve(curve.name, [1, 0], "grp")
+
+    assert created == "grp"
+    assert len(state.current_graph.curves) == 2
+    assert len(bus.curve_updated.emitted) == 1

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -201,3 +201,18 @@ def test_create_bit_curves_with_nan_values(service):
     assert created == ["nan[0]", "nan[1]"]
     assert np.isnan(state.current_graph.curves[1].y[1])
     assert np.isnan(state.current_graph.curves[2].y[1])
+
+
+def test_create_bit_group_curve(service):
+    svc, state, _ = service
+    svc.add_graph()
+    graph = list(state.graphs.keys())[0]
+    curve = CurveData(name="base", x=[0, 1, 2, 3], y=[0, 1, 2, 3])
+    svc.add_curve(graph, curve=curve)
+
+    created = svc.create_bit_group_curve("base", [1, 0], "grp")
+
+    assert created == "grp"
+    assert len(state.current_graph.curves) == 2
+    new_curve = state.current_graph.curves[1]
+    assert np.array_equal(new_curve.y, [0, 2, 1, 3])

--- a/ui/widgets/__init__.py
+++ b/ui/widgets/__init__.py
@@ -1,0 +1,1 @@
+from .bit_group_widget import BitGroupWidget

--- a/ui/widgets/bit_group_widget.py
+++ b/ui/widgets/bit_group_widget.py
@@ -1,0 +1,84 @@
+"""Widget for creating grouped bit curves."""
+
+from PyQt5 import QtWidgets
+from core.app_state import AppState
+
+
+class BitGroupWidget(QtWidgets.QWidget):
+    """Widget to manage bit groups for curve decomposition."""
+
+    def __init__(self, controller=None, parent=None):
+        super().__init__(parent)
+        self.controller = controller
+        self._setup_ui()
+
+    def set_controller(self, controller):
+        self.controller = controller
+
+    def _setup_ui(self):
+        layout = QtWidgets.QVBoxLayout(self)
+        self.table = QtWidgets.QTableWidget(0, 3)
+        self.table.setHorizontalHeaderLabels(["Nom", "Bits", ""])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+        btn_layout = QtWidgets.QHBoxLayout()
+        self.add_btn = QtWidgets.QPushButton("Ajouter un groupe")
+        self.create_all_btn = QtWidgets.QPushButton("Créer tous")
+        btn_layout.addWidget(self.add_btn)
+        btn_layout.addStretch()
+        btn_layout.addWidget(self.create_all_btn)
+        layout.addLayout(btn_layout)
+
+        self.add_btn.clicked.connect(self.add_row)
+        self.create_all_btn.clicked.connect(self.create_all)
+
+    def add_row(self):
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        name_edit = QtWidgets.QLineEdit()
+        bits_edit = QtWidgets.QLineEdit()
+        create_btn = QtWidgets.QPushButton("Créer")
+        create_btn.clicked.connect(lambda: self.create_row(row))
+        self.table.setCellWidget(row, 0, name_edit)
+        self.table.setCellWidget(row, 1, bits_edit)
+        self.table.setCellWidget(row, 2, create_btn)
+
+    def _parse_bits(self, text):
+        indices = []
+        for part in text.replace(" ", "").split(','):
+            if not part:
+                continue
+            if '-' in part:
+                start, end = part.split('-', 1)
+                indices.extend(range(int(start), int(end) + 1))
+            else:
+                indices.append(int(part))
+        return indices
+
+    def create_row(self, row):
+        if not self.controller:
+            return
+        name_edit = self.table.cellWidget(row, 0)
+        bits_edit = self.table.cellWidget(row, 1)
+        try:
+            indices = self._parse_bits(bits_edit.text())
+        except Exception:
+            QtWidgets.QMessageBox.warning(self, "Erreur", "Indices invalides")
+            return
+        if not indices:
+            QtWidgets.QMessageBox.warning(self, "Erreur", "Aucun bit spécifié")
+            return
+        state = AppState.get_instance()
+        curve = state.current_curve
+        if not curve:
+            return
+        group_name = name_edit.text().strip() or None
+        try:
+            self.controller.create_bit_group_curve(curve.name, indices, group_name)
+        except Exception as e:
+            QtWidgets.QMessageBox.warning(self, "Erreur", str(e))
+
+    def create_all(self):
+        for row in range(self.table.rowCount()):
+            self.create_row(row)


### PR DESCRIPTION
## Summary
- enable custom bit grouping via new `BitGroupWidget`
- implement `create_bit_group_curve` in `GraphService` and controller
- integrate grouping UI into `PropertiesPanel`
- test grouped bit curve generation

## Testing
- `pre-commit run --files ui/widgets/bit_group_widget.py ui/PropertiesPanel.py controllers.py core/graph_service.py tests/test_graph_service.py tests/test_graph_controller.py ui/widgets/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f42a2965c832d92cd8daa092a1e50