### PR TITLE
Add editable zone table with delete option

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -235,6 +235,18 @@ class GraphController:
         self.service.add_zone(zone)
         signal_bus.graph_updated.emit()
         self.ui.refresh_plot()
+
+    def update_zone(self, index: int, zone: dict):
+        logger.debug(f"🗒 [GraphController.update_zone] index={index} zone={zone}")
+        self.service.update_zone(index, zone)
+        signal_bus.graph_updated.emit()
+        self.ui.refresh_plot()
+
+    def remove_zone(self, index: int):
+        logger.debug(f"🗒 [GraphController.remove_zone] index={index}")
+        self.service.remove_zone(index)
+        signal_bus.graph_updated.emit()
+        self.ui.refresh_plot()
     
     def set_graph_visible(self, graph_name: str, visible: bool):
         logger.debug(f"👁 [GraphController.set_graph_visible] {graph_name} → {visible}")

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -586,6 +586,24 @@ class GraphService:
             return
         graph.zones.append(zone)
 
+    def update_zone(self, index: int, zone: dict):
+        """Update a zone at the given index."""
+        logger.debug(f"🗒 [GraphService.update_zone] index={index} zone={zone}")
+        graph = self.state.current_graph
+        if not graph:
+            return
+        if 0 <= index < len(graph.zones):
+            graph.zones[index] = zone
+
+    def remove_zone(self, index: int):
+        """Remove the zone at the given index."""
+        logger.debug(f"🗒 [GraphService.remove_zone] index={index}")
+        graph = self.state.current_graph
+        if not graph:
+            return
+        if 0 <= index < len(graph.zones):
+            graph.zones.pop(index)
+
     def apply_mode(self, graph_name: str, mode: str):
         """Apply a predefined configuration to the given graph."""
         logger.debug(f"🎛 [GraphService.apply_mode] graph={graph_name} mode={mode}")

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -150,6 +150,22 @@ def test_add_zone(service):
     assert zones[0]["type"] == "linear"
 
 
+def test_remove_zone(service):
+    svc, state, _ = service
+    svc.add_graph()
+    name = list(state.graphs.keys())[0]
+    svc.select_graph(name)
+
+    svc.add_zone({"type": "linear", "bounds": [0, 1]})
+    svc.add_zone({"type": "rect", "rect": [0, 0, 1, 1]})
+
+    svc.remove_zone(0)
+
+    zones = state.current_graph.zones
+    assert len(zones) == 1
+    assert zones[0]["type"] == "rect"
+
+
 def test_bring_curve_to_front_moves_curve(service):
     svc, state, _ = service
     svc.add_graph()


### PR DESCRIPTION
## Summary
- show custom zone parameters directly in the properties table
- allow editing zone values inline and add delete button
- support updating and removing zones in controller/service
- test zone removal

## Testing
- `pre-commit run --files ui/PropertiesPanel.py core/graph_service.py controllers.py tests/test_graph_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0a0968e4832dab5a988a4081207c