### PR TITLE
Hide satellite item tables and add buttons

### DIFF
--- a/ui/PropertiesPanel.py
+++ b/ui/PropertiesPanel.py
@@ -437,6 +437,9 @@ class PropertiesPanel(QtWidgets.QTabWidget):
             btn_row.addWidget(add_btn)
             btn_row.addWidget(edit_btn)
             v.addLayout(btn_row)
+            # Hide table listing items and the add button as requested
+            table.hide()
+            add_btn.hide()
             toggle(False)
             return group, checkbox, color_btn, size_spin, table, add_btn, edit_btn
 


### PR DESCRIPTION
## Summary
- hide the tables that list satellite items in PropertiesPanel
- hide the associated "Ajouter" buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6aefd5f0832d8a86ee448ab0300c