### PR TITLE
Add satellite edit mode tests

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -222,6 +222,14 @@ class GraphController:
         signal_bus.graph_updated.emit()
         self.ui.refresh_plot()
 
+    def set_satellite_edit_mode(self, enabled: bool):
+        logger.debug(
+            f"🛰 [GraphController.set_satellite_edit_mode] enabled={enabled}"
+        )
+        self.service.set_satellite_edit_mode(enabled)
+        signal_bus.graph_updated.emit()
+        self.ui.refresh_plot()
+
     def add_satellite_item(self, zone: str, item: dict):
         logger.debug(
             f"🛰 [GraphController.add_satellite_item] zone={zone} item={item}"

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -567,6 +567,16 @@ class GraphService:
         if zone in graph.satellite_settings:
             graph.satellite_settings[zone]["size"] = size
 
+    def set_satellite_edit_mode(self, enabled: bool):
+        """Toggle edition mode for satellite items on the current graph."""
+        logger.debug(
+            f"🛰 [GraphService.set_satellite_edit_mode] enabled={enabled}"
+        )
+        graph = self.state.current_graph
+        if not graph:
+            return
+        graph.satellite_edit_mode = enabled
+
     def add_satellite_item(self, zone: str, item: dict):
         """Append an item description to a satellite zone."""
         logger.debug(

--- a/core/models.py
+++ b/core/models.py
@@ -122,6 +122,8 @@ class GraphData:
         }
     )
 
+    satellite_edit_mode: bool = False
+
     zones: List[dict] = field(default_factory=list)
 
 

--- a/tests/test_graph_controller.py
+++ b/tests/test_graph_controller.py
@@ -232,3 +232,16 @@ def test_controller_create_bit_group_curve(controller):
     assert created == "grp"
     assert len(state.current_graph.curves) == 2
     assert len(bus.curve_updated.emitted) == 1
+
+
+def test_set_satellite_edit_mode_triggers_update(controller):
+    c, state, bus = controller
+    c.add_graph()
+    bus.graph_updated.emitted.clear()
+    c.ui.plot_calls = 0
+
+    c.set_satellite_edit_mode(True)
+
+    assert state.current_graph.satellite_edit_mode is True
+    assert len(bus.graph_updated.emitted) == 1
+    assert c.ui.plot_calls == 1

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -294,3 +294,36 @@ def test_logic_analyzer_mode_applies_offsets(service):
     svc.apply_mode(gname, "logic_analyzer")
     assert c3.offset == 0
     assert c1.offset == 1
+
+
+def test_satellite_settings_are_graph_specific(service):
+    svc, state, _ = service
+    svc.add_graph()
+    g1 = list(state.graphs.keys())[0]
+    svc.add_graph()
+    g2 = list(state.graphs.keys())[1]
+
+    svc.select_graph(g1)
+    svc.set_satellite_visible("left", True)
+    svc.set_satellite_size("left", 150)
+    svc.set_satellite_color("left", "#123456")
+    svc.set_satellite_edit_mode(True)
+
+    svc.select_graph(g2)
+    svc.set_satellite_visible("left", False)
+    svc.set_satellite_size("left", 200)
+    svc.set_satellite_color("left", "#abcdef")
+    svc.set_satellite_edit_mode(False)
+
+    g1_data = state.graphs[g1]
+    g2_data = state.graphs[g2]
+
+    assert g1_data.satellite_visibility["left"] is True
+    assert g1_data.satellite_settings["left"]["size"] == 150
+    assert g1_data.satellite_settings["left"]["color"] == "#123456"
+    assert g1_data.satellite_edit_mode is True
+
+    assert g2_data.satellite_visibility["left"] is False
+    assert g2_data.satellite_settings["left"]["size"] == 200
+    assert g2_data.satellite_settings["left"]["color"] == "#abcdef"
+    assert g2_data.satellite_edit_mode is False


### PR DESCRIPTION
## Summary
- add `satellite_edit_mode` attribute on `GraphData`
- support satellite edit mode in `GraphService` and `GraphController`
- ensure satellite settings are graph specific
- test controller method triggers updates

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb540aa34832d9736edb0bd9d5283