### PR TITLE
Fix satellite refresh to respect edit mode

### DIFF
--- a/tests/test_refresh_satellites.py
+++ b/tests/test_refresh_satellites.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5 import QtWidgets
+
+# ensure repo root in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.models import GraphData
+from ui.views import MyPlotView
+
+
+def test_refresh_does_not_overwrite_set_items():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    graph = GraphData(name="g")
+    zone = "left"
+    graph.satellite_visibility[zone] = True
+    graph.satellite_settings[zone]["items"] = [
+        {"type": "text", "text": "old", "x": 0, "y": 0}
+    ]
+
+    view = MyPlotView(graph)
+    view.refresh_satellites()
+
+    new_items = [
+        {"type": "text", "text": "new", "x": 10, "y": 10}
+    ]
+    graph.satellite_settings[zone]["items"] = list(new_items)
+    view.refresh_satellites()
+
+    assert graph.satellite_settings[zone]["items"] == new_items

--- a/ui/views.py
+++ b/ui/views.py
@@ -294,10 +294,10 @@ class MyPlotView:
                 if item and item.widget():
                     item.widget().deleteLater()
 
-            if old_view:
+            edit_mode = self.graph_data.satellite_edit_mode.get(zone, False)
+            if old_view and edit_mode:
                 self.graph_data.satellite_settings[zone]["items"] = old_view.get_items()
 
-            edit_mode = self.graph_data.satellite_edit_mode.get(zone, False)
             view = SatelliteZoneView(editable=edit_mode)
             layout.addWidget(view)
             view.setSceneRect(0, 0, box.width(), box.height())


### PR DESCRIPTION
## Summary
- restore satellite items only in edit mode
- add regression test for satellite item refresh logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f21af44bc832d976adea7e00f81a0