### PR TITLE
Fix drag-drop error with satellite zones

### DIFF
--- a/ui/satellite_zone_view.py
+++ b/ui/satellite_zone_view.py
@@ -19,12 +19,14 @@ class _DraggableProxyWidget(QtWidgets.QGraphicsProxyWidget):
         return super().itemChange(change, value)
 
 
-class _DraggableRectItem(QtWidgets.QGraphicsRectItem, QtCore.QObject):
+class _DraggableRectItem(QtCore.QObject, QtWidgets.QGraphicsRectItem):
+    """QGraphicsRectItem that can emit a ``moved`` signal."""
+
     moved = QtCore.pyqtSignal()
 
     def __init__(self, *args, **kwargs):
-        QtWidgets.QGraphicsRectItem.__init__(self, *args, **kwargs)
         QtCore.QObject.__init__(self)
+        QtWidgets.QGraphicsRectItem.__init__(self, *args, **kwargs)
 
     def itemChange(self, change, value):
         if change == QtWidgets.QGraphicsItem.ItemPositionHasChanged:


### PR DESCRIPTION
## Summary
- ensure `_DraggableRectItem` inherits from `QObject`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f252e4d5c832d95e2ff71283d7a45