### PR TITLE
Fix QGraphicsRectItem init for DraggableRectItem

### DIFF
--- a/ui/satellite_zone_view.py
+++ b/ui/satellite_zone_view.py
@@ -25,8 +25,8 @@ class _DraggableRectItem(QtCore.QObject, QtWidgets.QGraphicsRectItem):
     moved = QtCore.pyqtSignal()
 
     def __init__(self, *args, **kwargs):
-        QtCore.QObject.__init__(self)
         QtWidgets.QGraphicsRectItem.__init__(self, *args, **kwargs)
+        QtCore.QObject.__init__(self)
 
     def itemChange(self, change, value):
         if change == QtWidgets.QGraphicsItem.ItemPositionHasChanged:


### PR DESCRIPTION
## Summary
- fix `_DraggableRectItem` initialization order so `QGraphicsRectItem` gets
  constructed before `QObject`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f264ef9c8832d81e73e2f69212d7c