### PR TITLE
Enhance satellite zone tables

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -230,6 +230,14 @@ class GraphController:
         signal_bus.graph_updated.emit()
         self.ui.refresh_plot()
 
+    def remove_satellite_item(self, zone: str, index: int):
+        logger.debug(
+            f"🛰 [GraphController.remove_satellite_item] zone={zone} index={index}"
+        )
+        self.service.remove_satellite_item(zone, index)
+        signal_bus.graph_updated.emit()
+        self.ui.refresh_plot()
+
     def set_satellite_items(self, zone: str, items: list):
         logger.debug(
             f"🛰 [GraphController.set_satellite_items] zone={zone} items={items}"

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -578,6 +578,19 @@ class GraphService:
         if zone in graph.satellite_settings:
             graph.satellite_settings[zone]["items"].append(item)
 
+    def remove_satellite_item(self, zone: str, index: int):
+        """Remove an item from a satellite zone."""
+        logger.debug(
+            f"🛰 [GraphService.remove_satellite_item] zone={zone} index={index}"
+        )
+        graph = self.state.current_graph
+        if not graph:
+            return
+        if zone in graph.satellite_settings:
+            items = graph.satellite_settings[zone]["items"]
+            if 0 <= index < len(items):
+                items.pop(index)
+
     def set_satellite_items(self, zone: str, items: list):
         """Replace the list of items for a satellite zone."""
         logger.debug(

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -152,6 +152,27 @@ def test_set_satellite_items(service):
     assert state.current_graph.satellite_settings["right"]["items"] == new_items
 
 
+def test_remove_satellite_item(service):
+    svc, state, _ = service
+    svc.add_graph()
+    name = list(state.graphs.keys())[0]
+    svc.select_graph(name)
+
+    svc.set_satellite_items(
+        "left",
+        [
+            {"type": "text", "text": "a"},
+            {"type": "text", "text": "b"},
+        ],
+    )
+
+    svc.remove_satellite_item("left", 0)
+
+    items = state.current_graph.satellite_settings["left"]["items"]
+    assert len(items) == 1
+    assert items[0]["text"] == "b"
+
+
 def test_add_zone(service):
     svc, state, _ = service
     svc.add_graph()


### PR DESCRIPTION
## Summary
- support removing satellite items in graph service and controller
- refresh satellite tables after adding an item
- show delete and modification columns for satellite tables
- test removal of satellite items and table refresh

## Testing
- `pre-commit run --files tests/test_satellite_integration.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb618a054832d98ad095317eaa930