### PR TITLE
Remove unused satellite_content

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -24,6 +24,12 @@ class GraphController:
             if properties_panel is not None:
                 self.ui.properties_panel = properties_panel
 
+        if properties_panel is not None:
+            try:
+                properties_panel.set_controller(self)
+            except Exception:
+                pass
+
     def load_project(self, graphs: dict):
         logger.debug("📂 [GraphController.load_project] Chargement du projet...")
         logger.debug(f"📊 [GraphController.load_project] Graphiques reçus : {list(graphs.keys())}")
@@ -190,21 +196,14 @@ class GraphController:
         signal_bus.graph_updated.emit()
         self.ui.refresh_plot()
 
-    def set_satellite_content(self, zone: str, content: str | None):
-        logger.debug(
-            f"🛰 [GraphController.set_satellite_content] zone={zone} content={content}"
-        )
-        self.service.set_satellite_content(zone, content)
-        signal_bus.graph_updated.emit()
-        self.ui.refresh_plot()
 
     def set_satellite_visible(self, zone: str, visible: bool):
         logger.debug(
             f"🛰 [GraphController.set_satellite_visible] zone={zone} visible={visible}"
         )
         self.service.set_satellite_visible(zone, visible)
-        signal_bus.graph_updated.emit()
         self.ui.refresh_plot()
+        signal_bus.graph_updated.emit()
 
     def set_satellite_color(self, zone: str, color: str):
         logger.debug(
@@ -252,6 +251,7 @@ class GraphController:
         )
         self.service.set_satellite_edit_mode(zone, enabled)
         self.ui.refresh_plot()
+        signal_bus.graph_updated.emit()
 
     def add_zone(self, zone: dict):
         logger.debug(f"🗒 [GraphController.add_zone] zone={zone}")

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -525,17 +525,6 @@ class GraphService:
             self.state.current_graph.y_min = y_min
             self.state.current_graph.y_max = y_max
 
-    def set_satellite_content(self, zone: str, content: Optional[str]):
-        """Define which widget content should appear in the given satellite zone."""
-        logger.debug(
-            f"🛰 [GraphService.set_satellite_content] zone={zone} content={content}"
-        )
-        graph = self.state.current_graph
-        if not graph:
-            return
-        if zone in graph.satellite_content:
-            graph.satellite_content[zone] = content
-            graph.satellite_visibility[zone] = bool(content)
 
     def set_satellite_visible(self, zone: str, visible: bool):
         logger.debug(

--- a/core/models.py
+++ b/core/models.py
@@ -104,14 +104,6 @@ class GraphData:
         }
     )
 
-    satellite_content: dict[str, Optional[str]] = field(
-        default_factory=lambda: {
-            "left": None,
-            "right": None,
-            "top": None,
-            "bottom": None,
-        }
-    )
 
     satellite_settings: dict[str, dict] = field(
         default_factory=lambda: {

--- a/tests/test_graph_data.py
+++ b/tests/test_graph_data.py
@@ -12,9 +12,9 @@ def test_satellite_dicts_are_instance_specific():
     g2 = GraphData("g2")
 
     g1.satellite_visibility["left"] = True
-    g1.satellite_content["right"] = "label"
+    g1.satellite_settings["right"]["color"] = "#ff0000"
     g1.satellite_edit_mode["top"] = True
 
     assert g2.satellite_visibility["left"] is False
-    assert g2.satellite_content["right"] is None
+    assert g2.satellite_settings["right"]["color"] == "#ffffff"
     assert g2.satellite_edit_mode["top"] is False

--- a/ui/satellite_zone_view.py
+++ b/ui/satellite_zone_view.py
@@ -144,7 +144,7 @@ class SatelliteZoneView(QtWidgets.QGraphicsView):
     def dropEvent(self, event):
         if self._editable and event.mimeData().hasText():
             typ = event.mimeData().text()
-            pos = self.mapToScene(event.pos())
+            pos = event.pos()
             self.create_item(typ, pos)
             # Immediately notify listeners so the underlying graph data gets
             # updated when new items are dropped.


### PR DESCRIPTION
## Summary
- delete satellite_content from `GraphData`
- clean GraphService and controller APIs
- ensure property panel knows its controller
- map drop positions directly in `SatelliteZoneView`
- update unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd6d02748832db6a1327a9583357d