### PR TITLE
Handle missing graph in satellite settings

### DIFF
--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -532,7 +532,10 @@ class GraphService:
         )
         graph = self.state.current_graph
         if not graph:
-            return
+            logger.warning(
+                "[GraphService.set_satellite_content] Aucun graphique sélectionné"
+            )
+            raise ValueError("Aucun graphique sélectionné")
         if zone in graph.satellite_content:
             graph.satellite_content[zone] = content
             graph.satellite_visibility[zone] = bool(content)
@@ -543,7 +546,10 @@ class GraphService:
         )
         graph = self.state.current_graph
         if not graph:
-            return
+            logger.warning(
+                "[GraphService.set_satellite_visible] Aucun graphique sélectionné"
+            )
+            raise ValueError("Aucun graphique sélectionné")
         if zone in graph.satellite_visibility:
             graph.satellite_visibility[zone] = visible
 
@@ -553,7 +559,10 @@ class GraphService:
         )
         graph = self.state.current_graph
         if not graph:
-            return
+            logger.warning(
+                "[GraphService.set_satellite_color] Aucun graphique sélectionné"
+            )
+            raise ValueError("Aucun graphique sélectionné")
         if zone in graph.satellite_settings:
             graph.satellite_settings[zone]["color"] = color
 
@@ -563,7 +572,10 @@ class GraphService:
         )
         graph = self.state.current_graph
         if not graph:
-            return
+            logger.warning(
+                "[GraphService.set_satellite_size] Aucun graphique sélectionné"
+            )
+            raise ValueError("Aucun graphique sélectionné")
         if zone in graph.satellite_settings:
             graph.satellite_settings[zone]["size"] = size
 
@@ -574,7 +586,10 @@ class GraphService:
         )
         graph = self.state.current_graph
         if not graph:
-            return
+            logger.warning(
+                "[GraphService.add_satellite_item] Aucun graphique sélectionné"
+            )
+            raise ValueError("Aucun graphique sélectionné")
         if zone in graph.satellite_settings:
             graph.satellite_settings[zone]["items"].append(item)
 
@@ -585,7 +600,10 @@ class GraphService:
         )
         graph = self.state.current_graph
         if not graph:
-            return
+            logger.warning(
+                "[GraphService.remove_satellite_item] Aucun graphique sélectionné"
+            )
+            raise ValueError("Aucun graphique sélectionné")
         if zone in graph.satellite_settings:
             items = graph.satellite_settings[zone]["items"]
             if 0 <= index < len(items):
@@ -598,7 +616,10 @@ class GraphService:
         )
         graph = self.state.current_graph
         if not graph:
-            return
+            logger.warning(
+                "[GraphService.set_satellite_items] Aucun graphique sélectionné"
+            )
+            raise ValueError("Aucun graphique sélectionné")
         if zone in graph.satellite_settings:
             graph.satellite_settings[zone]["items"] = list(items)
 
@@ -609,7 +630,10 @@ class GraphService:
         )
         graph = self.state.current_graph
         if not graph:
-            return
+            logger.warning(
+                "[GraphService.set_satellite_edit_mode] Aucun graphique sélectionné"
+            )
+            raise ValueError("Aucun graphique sélectionné")
         if zone in graph.satellite_edit_mode:
             graph.satellite_edit_mode[zone] = enabled
 

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -326,3 +326,51 @@ def test_set_satellite_edit_mode(service):
     assert state.current_graph.satellite_edit_mode["left"] is False
     svc.set_satellite_edit_mode("left", True)
     assert state.current_graph.satellite_edit_mode["left"] is True
+
+
+def test_set_satellite_content_without_graph_raises(service):
+    svc, _, _ = service
+    with pytest.raises(ValueError):
+        svc.set_satellite_content("left", "text")
+
+
+def test_set_satellite_visible_without_graph_raises(service):
+    svc, _, _ = service
+    with pytest.raises(ValueError):
+        svc.set_satellite_visible("left", True)
+
+
+def test_set_satellite_color_without_graph_raises(service):
+    svc, _, _ = service
+    with pytest.raises(ValueError):
+        svc.set_satellite_color("left", "#ffffff")
+
+
+def test_set_satellite_size_without_graph_raises(service):
+    svc, _, _ = service
+    with pytest.raises(ValueError):
+        svc.set_satellite_size("left", 100)
+
+
+def test_add_satellite_item_without_graph_raises(service):
+    svc, _, _ = service
+    with pytest.raises(ValueError):
+        svc.add_satellite_item("left", {"type": "text"})
+
+
+def test_remove_satellite_item_without_graph_raises(service):
+    svc, _, _ = service
+    with pytest.raises(ValueError):
+        svc.remove_satellite_item("left", 0)
+
+
+def test_set_satellite_items_without_graph_raises(service):
+    svc, _, _ = service
+    with pytest.raises(ValueError):
+        svc.set_satellite_items("left", [])
+
+
+def test_set_satellite_edit_mode_without_graph_raises(service):
+    svc, _, _ = service
+    with pytest.raises(ValueError):
+        svc.set_satellite_edit_mode("left", True)


### PR DESCRIPTION
## Summary
- raise `ValueError` when satellite methods are used without a selected graph
- add regression tests for these error cases

## Testing
- `pytest -q` *(fails: test_drop_updates_graph_data)*

------
https://chatgpt.com/codex/tasks/task_e_685fd6d0bc94832db2fca5d5bd42672e