### PR TITLE
Enhance logic analyzer UI

### DIFF
--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -11,15 +11,37 @@ logger = logging.getLogger(__name__)
 
 
 def apply_logic_analyzer_layout(graph: GraphData) -> None:
-    """Position curves like a logic analyzer view."""
+    """Position curves like a logic analyzer view and add background zones."""
+
+    # Clear any previously defined zones so we start from a clean state
+    graph.zones.clear()
+
     offset = 0
     for curve in reversed(graph.curves):
         if not curve.visible:
             continue
+
+        # Apply consistent gain and offset for logic analyzer readability
         curve.gain_mode = "multiplier"
         curve.gain = 0.9
         curve.units_per_grid = 1.0 / 0.9
         curve.offset = offset
+
+        # Alternate background colors for each curve lane
+        fill = "#eeeeee" if offset % 2 == 0 else "#dddddd"
+        graph.zones.append(
+            {
+                "type": "linear",
+                "bounds": [offset, offset + 1],
+                "orientation": "horizontal",
+                "fill_color": fill,
+                "fill_alpha": 100,
+                "line_color": fill,
+                "line_alpha": 0,
+                "line_width": 0,
+            }
+        )
+
         offset += 1
 
 

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -264,10 +264,22 @@ def test_logic_analyzer_mode_applies_offsets(service):
     assert c2.offset == 1
     assert c1.offset == 2
 
+    zones = state.graphs[gname].zones
+    assert len(zones) == 3
+    assert all(z["type"] == "linear" for z in zones)
+    assert all(z["orientation"] == "horizontal" for z in zones)
+    assert zones[0]["bounds"] == [0, 1]
+    assert zones[1]["bounds"] == [1, 2]
+    assert zones[2]["bounds"] == [2, 3]
+
     c2.visible = False
     svc.apply_mode(gname, "logic_analyzer")
     assert c3.offset == 0
     assert c1.offset == 1
+    zones = state.graphs[gname].zones
+    assert len(zones) == 2
+    assert zones[0]["bounds"] == [0, 1]
+    assert zones[1]["bounds"] == [1, 2]
 
 
 def test_satellite_object_operations(service):


### PR DESCRIPTION
## Summary
- add alternating grey zones in `logic_analyzer` mode
- test that `logic_analyzer` mode sets curve offsets and zones

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686143ef9308832db954689e12de8cd5