### PR TITLE
Remove unused orientation in zone definitions

### DIFF
--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -33,7 +33,6 @@ def apply_logic_analyzer_layout(graph: GraphData) -> None:
             {
                 "type": "hlinear",
                 "bounds": [offset, offset + 1],
-                "orientation": "horizontal",
                 "fill_color": fill,
                 "fill_alpha": 100,
                 "line_color": fill,

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -132,7 +132,7 @@ def test_add_zone(service):
     name = list(state.graphs.keys())[0]
     svc.select_graph(name)
 
-    svc.add_zone({"type": "vlinear", "bounds": [0, 1], "orientation": "vertical"})
+    svc.add_zone({"type": "vlinear", "bounds": [0, 1]})
 
     zones = state.current_graph.zones
     assert len(zones) == 1
@@ -145,7 +145,7 @@ def test_remove_zone(service):
     name = list(state.graphs.keys())[0]
     svc.select_graph(name)
 
-    svc.add_zone({"type": "vlinear", "bounds": [0, 1], "orientation": "vertical"})
+    svc.add_zone({"type": "vlinear", "bounds": [0, 1]})
     svc.add_zone({"type": "rect", "rect": [0, 0, 1, 1]})
 
     svc.remove_zone(0)
@@ -267,7 +267,6 @@ def test_logic_analyzer_mode_applies_offsets(service):
     zones = state.graphs[gname].zones
     assert len(zones) == 3
     assert all(z["type"] == "hlinear" for z in zones)
-    assert all(z["orientation"] == "horizontal" for z in zones)
     assert zones[0]["bounds"] == [0, 1]
     assert zones[1]["bounds"] == [1, 2]
     assert zones[2]["bounds"] == [2, 3]

--- a/ui/PropertiesPanel.py
+++ b/ui/PropertiesPanel.py
@@ -774,7 +774,6 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         # using the table's combobox.
         zone = {
             "type": "vlinear",
-            "orientation": "vertical",
             "name": "",
             "bounds": [0.0, 1.0],
             "line_color": generate_random_color(),
@@ -1161,7 +1160,6 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         current_type = combo.currentData()
         if current_type in {"hlinear", "vlinear"}:
             zone["type"] = current_type
-            zone["orientation"] = "horizontal" if current_type == "hlinear" else "vertical"
         if isinstance(name_edit, QtWidgets.QLineEdit):
             zone["name"] = name_edit.text()
         if isinstance(line_btn, QtWidgets.QPushButton):

--- a/ui/views.py
+++ b/ui/views.py
@@ -173,7 +173,7 @@ class MyPlotView:
 
             if ztype in {"hlinear", "vlinear"}:
                 bounds = zone.get("bounds", [0, 1])
-                orientation = zone.get("orientation", "vertical")
+                orientation = "horizontal" if ztype == "hlinear" else "vertical"
                 item = pg.LinearRegionItem(
                     values=bounds,
                     orientation=orientation,


### PR DESCRIPTION
## Summary
- drop `orientation` from zone dictionaries
- infer region orientation from zone type in `views`
- keep zone editing free from explicit orientation
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686166b32aa8832db8d8677f6f928c9e