### PR TITLE
Remove hidden orientation param

### DIFF
--- a/ui/custom_regions.py
+++ b/ui/custom_regions.py
@@ -1,0 +1,18 @@
+from pyqtgraph import LinearRegionItem
+
+
+class LinearRegion(LinearRegionItem):
+    """Vertical linear region with fixed orientation."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.pop("orientation", None)
+        super().__init__(*args, orientation="vertical", **kwargs)
+
+
+class HLinearRegion(LinearRegionItem):
+    """Horizontal linear region with fixed orientation."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.pop("orientation", None)
+        super().__init__(*args, orientation="horizontal", **kwargs)
+

--- a/ui/views.py
+++ b/ui/views.py
@@ -5,6 +5,7 @@ import time
 import pyqtgraph as pg
 from signal_bus import signal_bus
 from PyQt5.QtGui import QColor, QPainterPath
+from ui.custom_regions import LinearRegion, HLinearRegion
 from ui.widgets.plot_container import PlotContainerWidget
 import logging
 
@@ -173,10 +174,9 @@ class MyPlotView:
 
             if ztype in {"hlinear", "vlinear"}:
                 bounds = zone.get("bounds", [0, 1])
-                orientation = "horizontal" if ztype == "hlinear" else "vertical"
-                item = pg.LinearRegionItem(
+                region_cls = HLinearRegion if ztype == "hlinear" else LinearRegion
+                item = region_cls(
                     values=bounds,
-                    orientation=orientation,
                     brush=QtGui.QBrush(fill_qcolor),
                     pen=pen,
                 )


### PR DESCRIPTION
## Summary
- remove the use of `orientation` when creating custom zones
- add fixed-orientation `LinearRegion` and `HLinearRegion`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686170e6e470832da1e4eb7c819b381c