### PR TITLE
Enhance logic analyzer layout

### DIFF
--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -17,6 +17,7 @@ def apply_logic_analyzer_layout(graph: GraphData) -> None:
     graph.zones.clear()
 
     offset = 0
+    curve_offset = 0.05
     for curve in reversed(graph.curves):
         if not curve.visible:
             continue
@@ -25,7 +26,7 @@ def apply_logic_analyzer_layout(graph: GraphData) -> None:
         curve.gain_mode = "multiplier"
         curve.gain = 0.9
         curve.units_per_grid = 1.0 / 0.9
-        curve.offset = offset
+        curve.offset = offset + curve_offset
 
         # Alternate background colors for each curve lane
         fill = "#eeeeee" if offset % 2 == 0 else "#dddddd"
@@ -34,10 +35,10 @@ def apply_logic_analyzer_layout(graph: GraphData) -> None:
                 "type": "hlinear",
                 "bounds": [offset, offset + 1],
                 "fill_color": fill,
-                "fill_alpha": 100,
-                "line_color": fill,
-                "line_alpha": 0,
-                "line_width": 0,
+                "fill_alpha": 50,
+                "line_color": "#000000",
+                "line_alpha": 100,
+                "line_width": 1,
             }
         )
 

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -260,9 +260,9 @@ def test_logic_analyzer_mode_applies_offsets(service):
 
     svc.apply_mode(gname, "logic_analyzer")
 
-    assert c3.offset == 0
-    assert c2.offset == 1
-    assert c1.offset == 2
+    assert c3.offset == pytest.approx(0.05)
+    assert c2.offset == pytest.approx(1.05)
+    assert c1.offset == pytest.approx(2.05)
 
     zones = state.graphs[gname].zones
     assert len(zones) == 3
@@ -270,11 +270,14 @@ def test_logic_analyzer_mode_applies_offsets(service):
     assert zones[0]["bounds"] == [0, 1]
     assert zones[1]["bounds"] == [1, 2]
     assert zones[2]["bounds"] == [2, 3]
+    assert all(z["line_color"] == "#000000" for z in zones)
+    assert all(z["line_width"] == 1 for z in zones)
+    assert all(z["fill_alpha"] == 50 for z in zones)
 
     c2.visible = False
     svc.apply_mode(gname, "logic_analyzer")
-    assert c3.offset == 0
-    assert c1.offset == 1
+    assert c3.offset == pytest.approx(0.05)
+    assert c1.offset == pytest.approx(1.05)
     zones = state.graphs[gname].zones
     assert len(zones) == 2
     assert zones[0]["bounds"] == [0, 1]

--- a/ui/views.py
+++ b/ui/views.py
@@ -180,6 +180,10 @@ class MyPlotView:
                     brush=QtGui.QBrush(fill_qcolor),
                     pen=pen,
                 )
+                item.setMovable(False)
+                item.setHoverBrush(item.brush)
+                item.setAcceptedMouseButtons(QtCore.Qt.NoButton)
+                item.setZValue(100)
             elif ztype == "rect":
                 x, y, w, h = zone.get("rect", [0, 0, 1, 1])
                 item = QtWidgets.QGraphicsRectItem(x, y, w, h)
@@ -201,6 +205,8 @@ class MyPlotView:
                 item.setPen(pen)
             else:
                 continue
+            item.setAcceptedMouseButtons(QtCore.Qt.NoButton)
+            item.setZValue(100)
             self.plot_widget.addItem(item)
 
         end = time.perf_counter()


### PR DESCRIPTION
## Summary
- tweak logic analyzer layout
- set unmovable zones without hover highlighting
- keep zones on top of plot
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686175d78424832da664a7a11d57df23