### PR TITLE
Fix property panel resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ python main.py
 
 When importing curves from files (CSV, JSON, BIN, etc.) a selection dialog
 lets you choose which curves are actually added to the project.
+
+## Resizing Panels
+
+All panels are dock widgets that can be resized freely. The properties panel no longer has a fixed height, so you can drag the dock borders to allocate more space vertically or horizontally. Use the "Dispositions" menu to save or restore a custom layout.

--- a/ui/PropertiesPanel.py
+++ b/ui/PropertiesPanel.py
@@ -152,8 +152,10 @@ class PropertiesPanel(QtWidgets.QTabWidget):
 
         super().__init__(parent)
         self.controller = controller
-        # Limit the overall height so the dock doesn't occupy too much space
-        self.setMaximumHeight(400)
+        # Allow the panel to expand to fill the available dock area
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
+        )
         self.setup_ui()
         self._connect_signals()
 


### PR DESCRIPTION
## Summary
- allow PropertiesPanel to expand so the dock area can be resized
- document how to resize panels in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862cb8ef278832db09b7a24f008504a