### PR TITLE
Add Rohde & Schwarz file importer

### DIFF
--- a/IO_dossier/__init__.py
+++ b/IO_dossier/__init__.py
@@ -8,5 +8,5 @@
 __version__ = 'x.x'
 
 # Main class
-from RTxReadBin import RTxReadBin
+from .RTxReadBin import RTxReadBin
 

--- a/tests/test_rohde_loader.py
+++ b/tests/test_rohde_loader.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from IO_dossier import curve_loader_factory as clf
+
+
+def test_load_rohde_schwarz_bin(monkeypatch):
+    def fake_read(path):
+        y = np.array([[[1, 10]], [[2, 20]], [[3, 30]]], dtype=np.float32)
+        x = np.array([0.0, 0.5, 1.0])
+        return y, x, {}
+
+    monkeypatch.setattr(clf, "RTxReadBin", fake_read)
+    curves = clf.load_rohde_schwarz_bin("dummy")
+    assert len(curves) == 2
+    assert np.array_equal(curves[0].y, np.array([1, 2, 3], dtype=np.float32))
+    assert np.array_equal(curves[1].y, np.array([10, 20, 30], dtype=np.float32))
+    assert np.array_equal(curves[0].x, np.array([0.0, 0.5, 1.0]))

--- a/ui/dialogs/import_curve_dialog.py
+++ b/ui/dialogs/import_curve_dialog.py
@@ -31,6 +31,7 @@ class ImportCurveDialog(QDialog):
         layout.addWidget(QLabel("Choisissez le format de fichier :"))
         self.format_combo = QComboBox()
         self.format_combo.addItem("Oscilloscope Keysight / fichier .BIN", "keysight_bin")
+        self.format_combo.addItem("Oscilloscope Rohde & Schwarz / fichier .BIN", "rohde_schwarz_bin")
         self.format_combo.addItem("Gestionnaire de courbes / JSON", "internal_json")
         self.format_combo.addItem("Oscilloscope Keysight V5 / JSON", "keysight_json_v5")
         self.format_combo.addItem("Oscilloscope TEKTRO V1.2 / JSON", "tektro_json_v1_2")


### PR DESCRIPTION
## Summary
- support Rohde & Schwarz oscilloscopes via `load_rohde_schwarz_bin`
- expose new option in import dialog
- fix relative import in IO package
- test new loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815d23f628832d924b54a07a262f32