### PR TITLE
Avoid automatic switch to mode tab

### DIFF
--- a/ui/application_coordinator.py
+++ b/ui/application_coordinator.py
@@ -142,14 +142,12 @@ class ApplicationCoordinator:
 
     def _on_curve_updated(self):
         self.main_window.show_curve_tab()
-        self.main_window.show_mode_tab()
 
     def _on_graph_selected(self, graph_name):
         self.main_window.show_graph_tab()
 
     def _on_curve_selected(self, graph_name, curve_name):
         self.main_window.show_curve_tab(graph_name, curve_name)
-        self.main_window.show_mode_tab()
 
     def _handle_rename_requested(self, kind, old_name, new_name):
         if kind == "graph":

--- a/ui/ui_main_window.py
+++ b/ui/ui_main_window.py
@@ -275,6 +275,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def show_curve_tab(self, graph_name=None, curve_name=None):
         logger.debug(f"[MainWindow] Activation de l'onglet Courbe : {graph_name} > {curve_name}")
         self.right_panel.setTabEnabled(1, True)
+        self.right_panel.setTabEnabled(2, True)
         self.right_panel.setCurrentIndex(1)
 
     def show_mode_tab(self):


### PR DESCRIPTION
## Summary
- enable Mode tab when a curve is selected without switching to it
- stop automatically moving to Mode tab when a curve is updated or selected

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e7dc6de2c832d9e1a9b8ea6635e66