### PR TITLE
feat: expose advanced axis controls

### DIFF
--- a/IO_dossier/serializers.py
+++ b/IO_dossier/serializers.py
@@ -71,9 +71,13 @@ def graph_to_dict(graph: GraphData) -> dict:
             "log_x": graph.log_x,
             "log_y": graph.log_y,
             "font": graph.font,
+            "auto_range_x": graph.auto_range_x,
+            "auto_range_y": graph.auto_range_y,
             "fix_y_range": graph.fix_y_range,
             "y_min": graph.y_min,
             "y_max": graph.y_max,
+            "mouse_enabled_x": graph.mouse_enabled_x,
+            "mouse_enabled_y": graph.mouse_enabled_y,
             "x_unit": graph.x_unit,
             "y_unit": graph.y_unit,
             "x_format": graph.x_format,
@@ -92,9 +96,13 @@ def dict_to_graph(data: dict) -> GraphData:
     g.log_x = props.get("log_x", False)
     g.log_y = props.get("log_y", False)
     g.font = props.get("font", "Arial")
+    g.auto_range_x = props.get("auto_range_x", True)
+    g.auto_range_y = props.get("auto_range_y", True)
     g.fix_y_range = props.get("fix_y_range", False)
     g.y_min = props.get("y_min", -5.0)
     g.y_max = props.get("y_max", 5.0)
+    g.mouse_enabled_x = props.get("mouse_enabled_x", True)
+    g.mouse_enabled_y = props.get("mouse_enabled_y", True)
     g.x_unit = props.get("x_unit", "")
     g.y_unit = props.get("y_unit", "")
     g.x_format = props.get("x_format", "normal")

--- a/controllers.py
+++ b/controllers.py
@@ -178,6 +178,18 @@ class GraphController:
         signal_bus.graph_updated.emit()
         self.ui.refresh_plot()
 
+    def set_auto_range_x(self, enabled: bool):
+        logger.debug(f"📏 [GraphController.set_auto_range_x] {enabled}")
+        self.service.set_auto_range_x(enabled)
+        signal_bus.graph_updated.emit()
+        self.ui.refresh_plot()
+
+    def set_auto_range_y(self, enabled: bool):
+        logger.debug(f"📏 [GraphController.set_auto_range_y] {enabled}")
+        self.service.set_auto_range_y(enabled)
+        signal_bus.graph_updated.emit()
+        self.ui.refresh_plot()
+
     def set_fix_y_range(self, fix: bool):
         logger.debug(f"📊 [GraphController.set_fix_y_range] {fix}")
         self.service.set_fix_y_range(fix)
@@ -187,6 +199,18 @@ class GraphController:
     def set_y_limits(self, y_min: float, y_max: float):
         logger.debug(f"📉 [GraphController.set_y_limits] {y_min} → {y_max}")
         self.service.set_y_limits(y_min, y_max)
+        signal_bus.graph_updated.emit()
+        self.ui.refresh_plot()
+
+    def set_mouse_enabled_x(self, enabled: bool):
+        logger.debug(f"🖱️ [GraphController.set_mouse_enabled_x] {enabled}")
+        self.service.set_mouse_enabled_x(enabled)
+        signal_bus.graph_updated.emit()
+        self.ui.refresh_plot()
+
+    def set_mouse_enabled_y(self, enabled: bool):
+        logger.debug(f"🖱️ [GraphController.set_mouse_enabled_y] {enabled}")
+        self.service.set_mouse_enabled_y(enabled)
         signal_bus.graph_updated.emit()
         self.ui.refresh_plot()
 
@@ -374,3 +398,11 @@ class GraphController:
     def reset_zoom(self):
         logger.debug("🔍 [GraphController.reset_zoom] Réinitialisation du zoom")
         self.ui.reset_zoom()
+
+    def reset_zoom_x(self):
+        logger.debug("🔍 [GraphController.reset_zoom_x] Réinitialisation du zoom X")
+        self.ui.reset_zoom_x()
+
+    def reset_zoom_y(self):
+        logger.debug("🔍 [GraphController.reset_zoom_y] Réinitialisation du zoom Y")
+        self.ui.reset_zoom_y()

--- a/core/graph_service.py
+++ b/core/graph_service.py
@@ -536,16 +536,39 @@ class GraphService:
         if self.state.current_graph:
             self.state.current_graph.y_format = fmt
 
+    def set_auto_range_x(self, enabled: bool):
+        logger.debug(f"📏 [GraphService.set_auto_range_x] {enabled}")
+        if self.state.current_graph:
+            self.state.current_graph.auto_range_x = enabled
+
+    def set_auto_range_y(self, enabled: bool):
+        logger.debug(f"📏 [GraphService.set_auto_range_y] {enabled}")
+        if self.state.current_graph:
+            self.state.current_graph.auto_range_y = enabled
+            if enabled:
+                self.state.current_graph.fix_y_range = False
+
     def set_fix_y_range(self, fix: bool):
         logger.debug(f"📊 [GraphService.set_fix_y_range] {fix}")
         if self.state.current_graph:
             self.state.current_graph.fix_y_range = fix
+            self.state.current_graph.auto_range_y = not fix
 
     def set_y_limits(self, y_min: float, y_max: float):
         logger.debug(f"📉 [GraphService.set_y_limits] {y_min} → {y_max}")
         if self.state.current_graph:
             self.state.current_graph.y_min = y_min
             self.state.current_graph.y_max = y_max
+
+    def set_mouse_enabled_x(self, enabled: bool):
+        logger.debug(f"🖱️ [GraphService.set_mouse_enabled_x] {enabled}")
+        if self.state.current_graph:
+            self.state.current_graph.mouse_enabled_x = enabled
+
+    def set_mouse_enabled_y(self, enabled: bool):
+        logger.debug(f"🖱️ [GraphService.set_mouse_enabled_y] {enabled}")
+        if self.state.current_graph:
+            self.state.current_graph.mouse_enabled_y = enabled
 
     def set_satellite_content(self, zone: str, content: Optional[str]):
         """Define which widget content should appear in the given satellite zone."""

--- a/core/models.py
+++ b/core/models.py
@@ -102,6 +102,8 @@ class GraphData:
     log_y: bool = False
     font: str = "Arial"
     visible: bool = True
+    auto_range_x: bool = True
+    auto_range_y: bool = True
     fix_y_range: bool = False
     y_min: float = -5.0
     y_max: float = 5.0
@@ -110,6 +112,8 @@ class GraphData:
     x_format: str = "normal"  # valeurs possibles : "normal", "scientific", "scaled"
     y_format: str = "normal"
     mode: str = "standard"  # mode d'affichage spécifique au graphique
+    mouse_enabled_x: bool = True
+    mouse_enabled_y: bool = True
     satellite_zones_visible: dict[str, bool] = field(
         default_factory=lambda: {
             "left": True,

--- a/tests/test_graph_controller.py
+++ b/tests/test_graph_controller.py
@@ -40,6 +40,10 @@ class DummyCoordinator:
         self.curve_calls += 1
     def reset_zoom(self):
         pass
+    def reset_zoom_x(self):
+        pass
+    def reset_zoom_y(self):
+        pass
 
 @pytest.fixture
 def controller(monkeypatch):
@@ -103,6 +107,26 @@ def test_controller_reset_zoom_invokes_ui(controller):
     c.ui.reset_zoom = stub
     c.reset_zoom()
 
+    assert called["count"] == 1
+
+
+def test_controller_reset_zoom_x_invokes_ui(controller):
+    c, _, _ = controller
+    called = {"count": 0}
+    def stub():
+        called["count"] += 1
+    c.ui.reset_zoom_x = stub
+    c.reset_zoom_x()
+    assert called["count"] == 1
+
+
+def test_controller_reset_zoom_y_invokes_ui(controller):
+    c, _, _ = controller
+    called = {"count": 0}
+    def stub():
+        called["count"] += 1
+    c.ui.reset_zoom_y = stub
+    c.reset_zoom_y()
     assert called["count"] == 1
 
 
@@ -232,5 +256,3 @@ def test_controller_create_bit_group_curve(controller):
     assert created == "grp"
     assert len(state.current_graph.curves) == 2
     assert len(bus.curve_updated.emitted) == 1
-
-

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -112,6 +112,7 @@ def test_axis_settings(service):
     assert g.fix_y_range is True
     assert g.y_min == -1
     assert g.y_max == 1
+    assert g.auto_range_y is False
 
 
 def test_set_time_offset(service):
@@ -122,6 +123,22 @@ def test_set_time_offset(service):
 
     svc.set_time_offset(2.5)
     assert state.current_curve.time_offset == 2.5
+
+
+def test_autorange_mouse_settings(service):
+    svc, state, _ = service
+    svc.add_graph()
+    name = list(state.graphs.keys())[0]
+    svc.select_graph(name)
+    svc.set_auto_range_x(False)
+    svc.set_auto_range_y(False)
+    svc.set_mouse_enabled_x(False)
+    svc.set_mouse_enabled_y(False)
+    g = state.current_graph
+    assert g.auto_range_x is False
+    assert g.auto_range_y is False
+    assert g.mouse_enabled_x is False
+    assert g.mouse_enabled_y is False
 
 
 
@@ -304,4 +321,3 @@ def test_satellite_object_operations(service):
 
     svc.remove_satellite_object("left", 0)
     assert len(state.current_graph.satellite_objects["left"]) == 1
-

--- a/ui/PropertiesPanel.py
+++ b/ui/PropertiesPanel.py
@@ -239,6 +239,26 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         self.logy_checkbox.toggled.connect(
             lambda val: self._call_graph_controller(self.controller.set_log_y, val)
         )
+        self.auto_x_checkbox.toggled.connect(
+            lambda val: self._call_graph_controller(
+                self.controller.set_auto_range_x, val
+            )
+        )
+        self.auto_y_checkbox.toggled.connect(
+            lambda val: self._call_graph_controller(
+                self.controller.set_auto_range_y, val
+            )
+        )
+        self.mouse_x_checkbox.toggled.connect(
+            lambda val: self._call_graph_controller(
+                self.controller.set_mouse_enabled_x, val
+            )
+        )
+        self.mouse_y_checkbox.toggled.connect(
+            lambda val: self._call_graph_controller(
+                self.controller.set_mouse_enabled_y, val
+            )
+        )
 
         # Nouvelles connexions pour les options d'axe
         self.x_unit_input.editingFinished.connect(
@@ -358,8 +378,14 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         self.darkmode_checkbox = QtWidgets.QCheckBox("Mode sombre")
         self.logx_checkbox = QtWidgets.QCheckBox("Échelle X logarithmique")
         self.logy_checkbox = QtWidgets.QCheckBox("Échelle Y logarithmique")
+        self.auto_x_checkbox = QtWidgets.QCheckBox("Auto-échelle X")
+        self.auto_y_checkbox = QtWidgets.QCheckBox("Auto-échelle Y")
+        self.mouse_x_checkbox = QtWidgets.QCheckBox("Souris activée X")
+        self.mouse_y_checkbox = QtWidgets.QCheckBox("Souris activée Y")
         self.font_combo = QtWidgets.QFontComboBox()
         self.button_reset_zoom = QtWidgets.QPushButton("🔍 Réinitialiser le zoom")
+        self.button_reset_zoom_x = QtWidgets.QPushButton("🔍 Zoom X")
+        self.button_reset_zoom_y = QtWidgets.QPushButton("🔍 Zoom Y")
 
         layout.addWidget(QtWidgets.QLabel("Graphique sélectionné :"))
         layout.addWidget(self.label_graph_name)
@@ -368,9 +394,15 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         layout.addWidget(self.darkmode_checkbox)
         layout.addWidget(self.logx_checkbox)
         layout.addWidget(self.logy_checkbox)
+        layout.addWidget(self.auto_x_checkbox)
+        layout.addWidget(self.auto_y_checkbox)
+        layout.addWidget(self.mouse_x_checkbox)
+        layout.addWidget(self.mouse_y_checkbox)
         layout.addWidget(QtWidgets.QLabel("Police :"))
         layout.addWidget(self.font_combo)
         layout.addWidget(self.button_reset_zoom)
+        layout.addWidget(self.button_reset_zoom_x)
+        layout.addWidget(self.button_reset_zoom_y)
 
         # ✅ Ajout : unités et formats des axes
         unit_layout = QtWidgets.QFormLayout()
@@ -1250,6 +1282,11 @@ class PropertiesPanel(QtWidgets.QTabWidget):
         self.darkmode_checkbox.setChecked(graph.dark_mode)
         self.logx_checkbox.setChecked(graph.log_x)
         self.logy_checkbox.setChecked(graph.log_y)
+        self.auto_x_checkbox.setChecked(graph.auto_range_x)
+        self.auto_y_checkbox.setChecked(graph.auto_range_y)
+        self.mouse_x_checkbox.setChecked(graph.mouse_enabled_x)
+        self.mouse_y_checkbox.setChecked(graph.mouse_enabled_y)
+        self.auto_y_checkbox.setEnabled(not graph.fix_y_range)
 
         # Police
         self.font_combo.setCurrentFont(QtGui.QFont(graph.font))

--- a/ui/application_coordinator.py
+++ b/ui/application_coordinator.py
@@ -77,6 +77,12 @@ class ApplicationCoordinator:
         self.properties_panel.button_reset_zoom.clicked.connect(
             self.controller.reset_zoom
         )
+        self.properties_panel.button_reset_zoom_x.clicked.connect(
+            self.controller.reset_zoom_x
+        )
+        self.properties_panel.button_reset_zoom_y.clicked.connect(
+            self.controller.reset_zoom_y
+        )
 
     def _handle_curve_selected(self, graph_name, curve_name):
         """Handle selection of a curve from the UI tree."""
@@ -164,5 +170,3 @@ class ApplicationCoordinator:
         elif kind == "curve":
             self.controller.remove_curve(name)
             self.graph_ui_coordinator.refresh_plot()
-
-

--- a/ui/graph_ui_coordinator.py
+++ b/ui/graph_ui_coordinator.py
@@ -78,3 +78,13 @@ class GraphUICoordinator:
         for name, view in self.views.items():
             logger.debug(f"  🔍 [reset_zoom] Vue : {name}")
             view.reset_zoom()
+
+    def reset_zoom_x(self):
+        logger.debug("[graph_ui_coordinator > reset_zoom_x()] ▶️ Réinitialisation du zoom X")
+        for name, view in self.views.items():
+            view.reset_zoom_x()
+
+    def reset_zoom_y(self):
+        logger.debug("[graph_ui_coordinator > reset_zoom_y()] ▶️ Réinitialisation du zoom Y")
+        for name, view in self.views.items():
+            view.reset_zoom_y()

--- a/ui/views.py
+++ b/ui/views.py
@@ -41,11 +41,14 @@ class MyPlotView:
         self.plot_widget.setLogMode(g.log_x, g.log_y)
         self.plot_widget.setBackground("k" if g.dark_mode else "w")
 
+        x_auto = g.auto_range_x
+        y_auto = g.auto_range_y and not g.fix_y_range
+        self.plot_widget.enableAutoRange(x=x_auto, y=y_auto)
         if g.fix_y_range:
-            self.plot_widget.enableAutoRange(False, False)
             self.plot_widget.setYRange(g.y_min, g.y_max)
-        else:
-            self.plot_widget.enableAutoRange(True, True)
+
+        vb = self.plot_widget.getViewBox()
+        vb.setMouseEnabled(x=g.mouse_enabled_x, y=g.mouse_enabled_y)
 
         self._format_axis(self.plot_widget.getAxis("bottom"), g.x_unit, g.x_format)
         self._format_axis(self.plot_widget.getAxis("left"), g.y_unit, g.y_format)
@@ -273,8 +276,28 @@ class MyPlotView:
         self.plot_widget.enableAutoRange()
 
     def reset_zoom(self):
-        """Convenience wrapper used by GraphUICoordinator."""
-        self.plot_widget.enableAutoRange()
+        """Reset both axes to show all data."""
+        vb = self.plot_widget.getViewBox()
+        vb.autoRange()
+        if self.graph_data.fix_y_range:
+            vb.setYRange(self.graph_data.y_min, self.graph_data.y_max, padding=0)
+
+    def reset_zoom_x(self):
+        """Reset only the X axis."""
+        vb = self.plot_widget.getViewBox()
+        bounds = vb.childrenBoundingRect()
+        if bounds is not None:
+            vb.setXRange(bounds.left(), bounds.right(), padding=0)
+
+    def reset_zoom_y(self):
+        """Reset only the Y axis."""
+        vb = self.plot_widget.getViewBox()
+        if self.graph_data.fix_y_range:
+            vb.setYRange(self.graph_data.y_min, self.graph_data.y_max, padding=0)
+        else:
+            bounds = vb.childrenBoundingRect()
+            if bounds is not None:
+                vb.setYRange(bounds.top(), bounds.bottom(), padding=0)
 
     def refresh_satellites(self):
         """Update visibility and content of satellite zones around the plot."""


### PR DESCRIPTION
## Summary
- allow per-axis auto-scaling and mouse interaction configuration
- add dedicated zoom reset buttons for overall, X-only and Y-only axes
- expose new axis controls in properties panel and persist them in project files

## Testing
- `pre-commit run --files controllers.py core/graph_service.py core/models.py tests/test_graph_controller.py tests/test_graph_service.py ui/PropertiesPanel.py ui/application_coordinator.py ui/graph_ui_coordinator.py ui/views.py IO_dossier/serializers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f611a3734832d8e5c7f7af798ccf9